### PR TITLE
Use canonical image_url and published_at columns for posts

### DIFF
--- a/api/posts/index.js
+++ b/api/posts/index.js
@@ -5,7 +5,7 @@ module.exports = async (req, res) => {
   try {
     if (req.method === 'GET') {
       const { rows } = await query(`
-        SELECT id, title, slug, excerpt, content, category, tags, author, image_url, created_at
+        SELECT id, title, slug, excerpt, content, category, tags, author, image_url, published_at
         FROM public.posts
         ORDER BY id DESC
       `);
@@ -38,7 +38,7 @@ module.exports = async (req, res) => {
           tags=EXCLUDED.tags,
           author=EXCLUDED.author,
           image_url=EXCLUDED.image_url
-        RETURNING *
+        RETURNING id, title, slug, excerpt, content, category, tags, author, image_url, published_at
       `, [title, slug, excerpt, content, category, tags, author, image_url]);
 
       return res.status(201).json(rows[0]);

--- a/schema.sql
+++ b/schema.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS posts (
   category TEXT,
   tags TEXT[],
   author TEXT,
-  hero_image TEXT,
+  image_url TEXT,
   content TEXT,
   published_at TIMESTAMPTZ DEFAULT now()
 );


### PR DESCRIPTION
## Summary
- replace noncanonical hero_image column with image_url in schema
- return published_at instead of created_at in posts API

## Testing
- `node - <<'NODE'
const handler = require('./api/posts/index.js');
const req = { method: 'GET' };
const res = {
  code: 200,
  status(code){ this.code = code; return this; },
  json(data){ console.log('CODE', this.code); console.log(JSON.stringify(data,null,2)); }
};
handler(req, res).catch(err => { console.error('error', err); });
NODE`


------
https://chatgpt.com/codex/tasks/task_e_6896941885fc8328ac35f8c259e3d195