### PR TITLE
Support slug in post update and delete

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,13 @@
   "private": true,
   "version": "1.0.0",
   "type": "commonjs",
+  "scripts": {
+    "test": "node --test"
+  },
   "dependencies": {
     "pg": "^8.11.3"
+  },
+  "devDependencies": {
+    "pg-mem": "^3.0.5"
   }
 }

--- a/tests/slug-update.test.js
+++ b/tests/slug-update.test.js
@@ -1,0 +1,47 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { newDb } = require('pg-mem');
+
+// Test updating a post via slug
+
+test('PUT /api/posts/:slug updates by slug', async () => {
+  const mem = newDb();
+  const pg = mem.adapters.createPg();
+  const pool = new pg.Pool();
+  await pool.query(`CREATE TABLE posts (
+    id SERIAL PRIMARY KEY,
+    slug TEXT UNIQUE NOT NULL,
+    title TEXT NOT NULL,
+    excerpt TEXT,
+    category TEXT,
+    tags TEXT[],
+    author TEXT,
+    image_url TEXT,
+    content TEXT,
+    published_at TIMESTAMPTZ DEFAULT now()
+  )`);
+  await pool.query(`INSERT INTO posts(slug, title) VALUES('test-slug', 'Old Title')`);
+
+  const db = require('../lib/db');
+  db.query = (text, params) => pool.query(text, params);
+
+  const handler = require('../api/posts/[id].js');
+
+  const req = { method: 'PUT', query: { id: 'test-slug' }, body: { title: 'New Title' } };
+  let statusCode;
+  let jsonBody;
+  const res = {
+    status(code) { statusCode = code; return this; },
+    json(data) { jsonBody = data; return this; },
+    setHeader() {},
+    end() {}
+  };
+
+  await handler(req, res);
+
+  assert.strictEqual(statusCode, 200);
+  assert.strictEqual(jsonBody.title, 'New Title');
+
+  const { rows } = await pool.query('SELECT title FROM posts WHERE slug = $1', ['test-slug']);
+  assert.strictEqual(rows[0].title, 'New Title');
+});


### PR DESCRIPTION
## Summary
- Allow PUT and DELETE handlers to target posts by numeric ID or slug
- Remove `updated_at` from UPDATE statement and use `image_url` field
- Add test verifying slug-based updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689697a6efe48328bdb74c1f1ac6c445