### PR TITLE
feat: add Stack Auth OAuth endpoints

### DIFF
--- a/api/auth/callback.js
+++ b/api/auth/callback.js
@@ -1,0 +1,38 @@
+const base = process.env.STACK_AUTH_BASE_URL || 'https://api.stack-auth.com';
+
+module.exports = async (req, res) => {
+  const code = req.query.code;
+  if (!code) {
+    return res.status(400).json({ error: 'Missing code' });
+  }
+
+  const proto = req.headers['x-forwarded-proto'] || (req.connection && req.connection.encrypted ? 'https' : 'http');
+  const host = req.headers.host;
+  const redirect_uri = `${proto}://${host}/api/auth/callback`;
+
+  try {
+    const tokenRes = await fetch(`${base}/api/v1/oauth/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        code,
+        project_id: process.env.STACK_AUTH_PROJECT_ID,
+        client_id: process.env.STACK_AUTH_CLIENT_ID,
+        redirect_uri
+      })
+    });
+
+    const data = await tokenRes.json();
+    if (!tokenRes.ok) {
+      return res.status(500).json(data);
+    }
+
+    const { access_token, expires_in } = data;
+    const maxAge = expires_in || 3600;
+    res.setHeader('Set-Cookie', `session=${access_token}; HttpOnly; Secure; SameSite=Lax; Max-Age=${maxAge}; Path=/`);
+    res.writeHead(302, { Location: '/' }).end();
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'TOKEN_EXCHANGE_FAILED' });
+  }
+};

--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -1,0 +1,19 @@
+const base = process.env.STACK_AUTH_BASE_URL || 'https://api.stack-auth.com';
+
+module.exports = (req, res) => {
+  const provider = req.query.provider || 'github';
+  const proto = req.headers['x-forwarded-proto'] || (req.connection && req.connection.encrypted ? 'https' : 'http');
+  const host = req.headers.host;
+  const redirect_uri = `${proto}://${host}/api/auth/callback`;
+
+  const url = new URL(`${base}/api/v1/oauth/authorize`);
+  url.searchParams.set('response_type', 'code');
+  url.searchParams.set('project_id', process.env.STACK_AUTH_PROJECT_ID);
+  url.searchParams.set('client_id', process.env.STACK_AUTH_CLIENT_ID);
+  url.searchParams.set('provider', provider);
+  url.searchParams.set('redirect_uri', redirect_uri);
+
+  res.status(302);
+  res.setHeader('Location', url.toString());
+  res.end();
+};

--- a/api/auth/logout.js
+++ b/api/auth/logout.js
@@ -1,0 +1,4 @@
+module.exports = (req, res) => {
+  res.setHeader('Set-Cookie', 'session=; HttpOnly; Secure; SameSite=Lax; Max-Age=0; Path=/');
+  res.writeHead(302, { Location: '/' }).end();
+};

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -1,0 +1,83 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+const originalEnv = { ...process.env };
+
+test('login redirects to Stack Auth', async () => {
+  process.env.STACK_AUTH_PROJECT_ID = 'pid';
+  process.env.STACK_AUTH_CLIENT_ID = 'cid';
+
+  const handler = require('../api/auth/login.js');
+  const req = { query: {}, headers: { host: 'example.com', 'x-forwarded-proto': 'https' } };
+  let statusCode; const headers = {};
+  const res = {
+    status(c){ statusCode = c; return this; },
+    setHeader(k,v){ headers[k]=v; },
+    end(){},
+  };
+  await handler(req,res);
+  assert.strictEqual(statusCode,302);
+  const loc = headers.Location;
+  const url = new URL(loc);
+  assert.strictEqual(url.origin,'https://api.stack-auth.com');
+  assert.strictEqual(url.pathname,'/api/v1/oauth/authorize');
+  assert.strictEqual(url.searchParams.get('response_type'),'code');
+  assert.strictEqual(url.searchParams.get('provider'),'github');
+  assert.strictEqual(url.searchParams.get('redirect_uri'),'https://example.com/api/auth/callback');
+  assert.strictEqual(url.searchParams.get('client_id'),'cid');
+  assert.strictEqual(url.searchParams.get('project_id'),'pid');
+});
+
+test('callback exchanges code and sets cookie', async () => {
+  process.env.STACK_AUTH_PROJECT_ID = 'pid';
+  process.env.STACK_AUTH_CLIENT_ID = 'cid';
+  const handler = require('../api/auth/callback.js');
+  const req = { query:{ code:'abc'}, headers:{ host:'example.com','x-forwarded-proto':'https'} };
+  let statusCode; const headers = {};
+  const res = {
+    status(c){ statusCode = c; return this; },
+    setHeader(k,v){ headers[k]=v; },
+    writeHead(c,h){ statusCode=c; Object.assign(headers,h); return this; },
+    end(){},
+    json(data){ headers.body=data; }
+  };
+
+  const tokenResponse = { access_token:'tok', expires_in:120 };
+  global.fetch = async (url, opts) => {
+    assert.strictEqual(url,'https://api.stack-auth.com/api/v1/oauth/token');
+    const body = JSON.parse(opts.body);
+    assert.strictEqual(body.code,'abc');
+    return { ok:true, json: async () => tokenResponse };
+  };
+
+  await handler(req,res);
+  assert.strictEqual(statusCode,302);
+  assert.strictEqual(headers.Location,'/');
+  assert.match(headers['Set-Cookie'], /session=tok/);
+  assert.match(headers['Set-Cookie'], /Max-Age=120/);
+  assert.match(headers['Set-Cookie'], /HttpOnly/);
+  assert.match(headers['Set-Cookie'], /Secure/);
+  assert.match(headers['Set-Cookie'], /SameSite=Lax/);
+
+  delete global.fetch;
+});
+
+test('logout clears session cookie', async () => {
+  const handler = require('../api/auth/logout.js');
+  const req = {};
+  let statusCode; const headers = {};
+  const res = {
+    setHeader(k,v){ headers[k]=v; },
+    writeHead(c,h){ statusCode=c; Object.assign(headers,h); return this; },
+    end(){},
+  };
+  await handler(req,res);
+  assert.strictEqual(statusCode,302);
+  assert.strictEqual(headers.Location,'/');
+  assert.match(headers['Set-Cookie'], /session=/);
+  assert.match(headers['Set-Cookie'], /Max-Age=0/);
+});
+
+test.after(() => {
+  process.env = originalEnv;
+});


### PR DESCRIPTION
## Summary
- add login endpoint that redirects to Stack Auth with provider and redirect URI
- add callback endpoint exchanging code for tokens and setting session cookie
- add logout endpoint to clear session cookie

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896a8814ab88328ac0f4d5070b9daa8