### PR TITLE
Require session cookie for posts mutations

### DIFF
--- a/api/posts/[id].js
+++ b/api/posts/[id].js
@@ -13,6 +13,12 @@ module.exports = async (req, res) => {
       return res.status(200).json(rows[0]);
     }
     if (req.method === 'PUT') {
+      const cookie = req.headers?.cookie || '';
+      const hasSession = cookie.split(';').some(c => c.trim().startsWith('session='));
+      if (!hasSession) {
+        return res.status(401).json({ error: 'unauthorized' });
+      }
+
       let body;
       try {
         body = typeof req.body === 'string' ? JSON.parse(req.body) : req.body;
@@ -30,6 +36,12 @@ module.exports = async (req, res) => {
       return res.status(200).json(rows[0]);
     }
     if (req.method === 'DELETE') {
+      const cookie = req.headers?.cookie || '';
+      const hasSession = cookie.split(';').some(c => c.trim().startsWith('session='));
+      if (!hasSession) {
+        return res.status(401).json({ error: 'unauthorized' });
+      }
+
       const isNumeric = /^\d+$/.test(id);
       const query = isNumeric
         ? 'DELETE FROM posts WHERE id = $1'

--- a/api/posts/index.js
+++ b/api/posts/index.js
@@ -13,6 +13,12 @@ module.exports = async (req, res) => {
     }
 
     if (req.method === 'POST') {
+      const cookie = req.headers?.cookie || '';
+      const hasSession = cookie.split(';').some(c => c.trim().startsWith('session='));
+      if (!hasSession) {
+        return res.status(401).json({ error: 'unauthorized' });
+      }
+
       const {
         title, slug,
         excerpt = '',

--- a/tests/malformed-json.test.js
+++ b/tests/malformed-json.test.js
@@ -25,7 +25,7 @@ test('PUT /api/posts/:slug returns 400 for invalid JSON', async () => {
 
   const handler = require('../api/posts/[id].js');
 
-  const req = { method: 'PUT', query: { id: 'test-slug' }, body: '{ invalid json' };
+  const req = { method: 'PUT', query: { id: 'test-slug' }, headers: { cookie: 'session=abc' }, body: '{ invalid json' };
   let statusCode;
   let jsonBody;
   const res = {

--- a/tests/posts-auth-required.test.js
+++ b/tests/posts-auth-required.test.js
@@ -1,0 +1,53 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+// Ensure POST requires session cookie
+
+test('POST /api/posts requires session cookie', async () => {
+  const handler = require('../api/posts/index.js');
+  const req = { method: 'POST', headers: {}, body: { title: 't', slug: 's' } };
+  let statusCode; let jsonBody;
+  const res = {
+    status(code) { statusCode = code; return this; },
+    json(data) { jsonBody = data; return this; },
+    setHeader() {},
+    end() {}
+  };
+  await handler(req, res);
+  assert.strictEqual(statusCode, 401);
+  assert.deepStrictEqual(jsonBody, { error: 'unauthorized' });
+});
+
+// Ensure PUT requires session cookie
+
+test('PUT /api/posts/:id requires session cookie', async () => {
+  const handler = require('../api/posts/[id].js');
+  const req = { method: 'PUT', query: { id: '1' }, headers: {}, body: { title: 'x' } };
+  let statusCode; let jsonBody;
+  const res = {
+    status(code) { statusCode = code; return this; },
+    json(data) { jsonBody = data; return this; },
+    setHeader() {},
+    end() {}
+  };
+  await handler(req, res);
+  assert.strictEqual(statusCode, 401);
+  assert.deepStrictEqual(jsonBody, { error: 'unauthorized' });
+});
+
+// Ensure DELETE requires session cookie
+
+test('DELETE /api/posts/:id requires session cookie', async () => {
+  const handler = require('../api/posts/[id].js');
+  const req = { method: 'DELETE', query: { id: '1' }, headers: {} };
+  let statusCode; let jsonBody;
+  const res = {
+    status(code) { statusCode = code; return this; },
+    json(data) { jsonBody = data; return this; },
+    setHeader() {},
+    end() {}
+  };
+  await handler(req, res);
+  assert.strictEqual(statusCode, 401);
+  assert.deepStrictEqual(jsonBody, { error: 'unauthorized' });
+});

--- a/tests/slug-update.test.js
+++ b/tests/slug-update.test.js
@@ -27,7 +27,7 @@ test('PUT /api/posts/:slug updates by slug', async () => {
 
   const handler = require('../api/posts/[id].js');
 
-  const req = { method: 'PUT', query: { id: 'test-slug' }, body: { title: 'New Title' } };
+  const req = { method: 'PUT', query: { id: 'test-slug' }, headers: { cookie: 'session=abc' }, body: { title: 'New Title' } };
   let statusCode;
   let jsonBody;
   const res = {


### PR DESCRIPTION
## Summary
- check for `session` cookie before allowing `POST /api/posts`
- require session cookie for `PUT` and `DELETE` on `/api/posts/:id`
- add tests for these auth rules and update existing tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896ac1ebfac8328ab80d9a29f7afa85