### PR TITLE
feat: secure endpoints with token verification

### DIFF
--- a/api/auth/me.js
+++ b/api/auth/me.js
@@ -1,0 +1,21 @@
+const { verifyToken } = require('../../lib/auth');
+
+module.exports = async (req, res) => {
+  try {
+    const cookie = req.headers?.cookie || '';
+    const session = cookie.split(';').find(c => c.trim().startsWith('session='));
+    if (!session) {
+      return res.status(401).json({ error: 'unauthorized' });
+    }
+    const token = session.split('=')[1];
+    const payload = await verifyToken(token);
+    if (!payload) {
+      return res.status(401).json({ error: 'unauthorized' });
+    }
+    const { sub, email, name } = payload;
+    return res.status(200).json({ sub, email, name });
+  } catch (err) {
+    console.error('/api/auth/me error:', err); 
+    return res.status(500).json({ error: 'SERVER_ERROR' });
+  }
+};

--- a/api/posts/[id].js
+++ b/api/posts/[id].js
@@ -1,4 +1,5 @@
 const db = require('../../lib/db');
+const { verifyToken } = require('../../lib/auth');
 
 module.exports = async (req, res) => {
   const id = req.query.id;
@@ -14,8 +15,10 @@ module.exports = async (req, res) => {
     }
     if (req.method === 'PUT') {
       const cookie = req.headers?.cookie || '';
-      const hasSession = cookie.split(';').some(c => c.trim().startsWith('session='));
-      if (!hasSession) {
+      const session = cookie.split(';').find(c => c.trim().startsWith('session='));
+      const token = session && session.split('=')[1];
+      const payload = token && await verifyToken(token);
+      if (!payload) {
         return res.status(401).json({ error: 'unauthorized' });
       }
 
@@ -37,8 +40,10 @@ module.exports = async (req, res) => {
     }
     if (req.method === 'DELETE') {
       const cookie = req.headers?.cookie || '';
-      const hasSession = cookie.split(';').some(c => c.trim().startsWith('session='));
-      if (!hasSession) {
+      const session = cookie.split(';').find(c => c.trim().startsWith('session='));
+      const token = session && session.split('=')[1];
+      const payload = token && await verifyToken(token);
+      if (!payload) {
         return res.status(401).json({ error: 'unauthorized' });
       }
 

--- a/api/posts/index.js
+++ b/api/posts/index.js
@@ -1,5 +1,6 @@
 // api/posts/index.js
 const { query } = require('../../lib/db');
+const { verifyToken } = require('../../lib/auth');
 
 module.exports = async (req, res) => {
   try {
@@ -14,8 +15,10 @@ module.exports = async (req, res) => {
 
     if (req.method === 'POST') {
       const cookie = req.headers?.cookie || '';
-      const hasSession = cookie.split(';').some(c => c.trim().startsWith('session='));
-      if (!hasSession) {
+      const session = cookie.split(';').find(c => c.trim().startsWith('session='));
+      const token = session && session.split('=')[1];
+      const payload = token && await verifyToken(token);
+      if (!payload) {
         return res.status(401).json({ error: 'unauthorized' });
       }
 

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,0 +1,31 @@
+const { createRemoteJWKSet, jwtVerify } = require('jose');
+
+const STACK_AUTH_BASE_URL = process.env.STACK_AUTH_BASE_URL || 'https://api.stack-auth.com';
+const PROJECT_ID = process.env.NEXT_PUBLIC_STACK_PROJECT_ID;
+
+let jwks;
+
+async function getJWKS() {
+  if (!jwks) {
+    if (!PROJECT_ID) {
+      throw new Error('NEXT_PUBLIC_STACK_PROJECT_ID is not set');
+    }
+    const url = `${STACK_AUTH_BASE_URL}/api/v1/projects/${PROJECT_ID}/.well-known/jwks.json`;
+    jwks = createRemoteJWKSet(new URL(url));
+  }
+  return jwks;
+}
+
+async function verifyToken(token) {
+  if (!token) return null;
+  try {
+    const JWKS = await getJWKS();
+    const { payload } = await jwtVerify(token, JWKS);
+    return payload;
+  } catch (err) {
+    console.error('verifyToken error:', err.message);
+    return null;
+  }
+}
+
+module.exports = { verifyToken };

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "node --test"
   },
   "dependencies": {
+    "jose": "^5.10.0",
     "pg": "^8.11.3"
   },
   "devDependencies": {

--- a/tests/auth-me.test.js
+++ b/tests/auth-me.test.js
@@ -1,0 +1,39 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+// Ensure /api/auth/me returns 401 without session
+
+test('GET /api/auth/me requires session cookie', async () => {
+  const handler = require('../api/auth/me.js');
+  const req = { headers: {} };
+  let statusCode; let jsonBody;
+  const res = {
+    status(code) { statusCode = code; return this; },
+    json(data) { jsonBody = data; return this; },
+    setHeader() {},
+    end() {},
+  };
+  await handler(req, res);
+  assert.strictEqual(statusCode, 401);
+  assert.deepStrictEqual(jsonBody, { error: 'unauthorized' });
+});
+
+// Ensure /api/auth/me returns payload fields
+
+test('GET /api/auth/me returns decoded fields', async () => {
+  const auth = require('../lib/auth');
+  auth.verifyToken = async () => ({ sub: '1', email: 'a@b.c', name: 'Alice' });
+  delete require.cache[require.resolve('../api/auth/me.js')];
+  const handler = require('../api/auth/me.js');
+  const req = { headers: { cookie: 'session=valid' } };
+  let statusCode; let jsonBody;
+  const res = {
+    status(code) { statusCode = code; return this; },
+    json(data) { jsonBody = data; return this; },
+    setHeader() {},
+    end() {},
+  };
+  await handler(req, res);
+  assert.strictEqual(statusCode, 200);
+  assert.deepStrictEqual(jsonBody, { sub: '1', email: 'a@b.c', name: 'Alice' });
+});

--- a/tests/malformed-json.test.js
+++ b/tests/malformed-json.test.js
@@ -23,9 +23,12 @@ test('PUT /api/posts/:slug returns 400 for invalid JSON', async () => {
   const db = require('../lib/db');
   db.query = (text, params) => pool.query(text, params);
 
+  const auth = require('../lib/auth');
+  auth.verifyToken = async () => ({ sub: '1' });
+
   const handler = require('../api/posts/[id].js');
 
-  const req = { method: 'PUT', query: { id: 'test-slug' }, headers: { cookie: 'session=abc' }, body: '{ invalid json' };
+  const req = { method: 'PUT', query: { id: 'test-slug' }, headers: { cookie: 'session=valid' }, body: '{ invalid json' };
   let statusCode;
   let jsonBody;
   const res = {

--- a/tests/slug-update.test.js
+++ b/tests/slug-update.test.js
@@ -25,9 +25,12 @@ test('PUT /api/posts/:slug updates by slug', async () => {
   const db = require('../lib/db');
   db.query = (text, params) => pool.query(text, params);
 
+  const auth = require('../lib/auth');
+  auth.verifyToken = async () => ({ sub: '1' });
+
   const handler = require('../api/posts/[id].js');
 
-  const req = { method: 'PUT', query: { id: 'test-slug' }, headers: { cookie: 'session=abc' }, body: { title: 'New Title' } };
+  const req = { method: 'PUT', query: { id: 'test-slug' }, headers: { cookie: 'session=valid' }, body: { title: 'New Title' } };
   let statusCode;
   let jsonBody;
   const res = {


### PR DESCRIPTION
## Summary
- validate session tokens against Stack Auth JWKS via new `verifyToken`
- expose `/api/auth/me` for retrieving authenticated user info
- enforce token verification on post creation and updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897405ebf248328868fa182fab18e01