### PR TITLE
Add basic auth controls with login/logout buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,11 +113,13 @@
             <div id="search-results" class="absolute left-0 mt-2 w-full bg-white dark:bg-slate-800 rounded-lg shadow-xl z-20 hidden"></div>
           </div>
 
-          <div id="login-links" class="flex items-center gap-2">
-            <a href="/api/auth/login?provider=github" class="px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Login</a>
-            <a href="/api/auth/login?provider=google" class="px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Google</a>
+          <div id="auth-area" class="flex items-center gap-2">
+            <a id="login-link" href="/api/auth/login" class="px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Login</a>
+            <div id="user-info" class="hidden items-center gap-2">
+              <span id="user-name" class="font-medium"></span>
+              <a id="logout-link" href="/api/auth/logout" class="px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Logout</a>
+            </div>
           </div>
-          <a id="logout-link" href="/api/auth/logout" class="hidden px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Logout</a>
 
           <button id="theme-toggle" class="w-10 h-10 rounded-full bg-slate-100 dark:bg-slate-800 flex items-center justify-center hover:bg-slate-200 dark:hover:bg-slate-700">
             <i class="fa-solid fa-sun block dark:hidden text-yellow-500"></i>
@@ -454,17 +456,26 @@
     document.addEventListener('DOMContentLoaded', loadAll);
   </script>
   <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      const loginLinks = document.getElementById('login-links');
-      const logoutLink = document.getElementById('logout-link');
-      const hasSession = document.cookie.includes('session=');
-      if (hasSession) {
-        loginLinks?.classList.add('hidden');
-        logoutLink?.classList.remove('hidden');
-      } else {
-        loginLinks?.classList.remove('hidden');
-        logoutLink?.classList.add('hidden');
+    document.addEventListener('DOMContentLoaded', async () => {
+      const loginLink = document.getElementById('login-link');
+      const userInfo = document.getElementById('user-info');
+      const userName = document.getElementById('user-name');
+      try {
+        const res = await fetch('/api/auth/me');
+        if (res.ok) {
+          const user = await res.json();
+          if (user && (user.name || user.email)) {
+            userName.textContent = user.name || user.email;
+            loginLink.classList.add('hidden');
+            userInfo.classList.remove('hidden');
+            return;
+          }
+        }
+      } catch (err) {
+        console.error('Auth check failed', err);
       }
+      loginLink.classList.remove('hidden');
+      userInfo.classList.add('hidden');
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- Add login and logout buttons to header
- Query `/api/auth/me` on load to toggle login and logout with user name

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68974523cd208328ade2404ea98712ec