### PR TITLE
chore(auth): unify project id env var

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 - Dateien: `api/**`
 - DB: Postgres (Neon), Tabelle `public.posts`
 - Spalten (wichtig): id, slug (unique), title, excerpt, content, category, tags text[], author, image_url, published_at timestamptz default now()
-- ENV: `DATABASE_URL` (SSL)
+- ENV: `DATABASE_URL` (SSL), `STACK_AUTH_PROJECT_ID`, `STACK_AUTH_CLIENT_ID`
 
 ## Regeln
 - Keine breaking Schema-Änderungen ohne Migration

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,14 +1,14 @@
 const { createRemoteJWKSet, jwtVerify } = require('jose');
 
 const STACK_AUTH_BASE_URL = process.env.STACK_AUTH_BASE_URL || 'https://api.stack-auth.com';
-const PROJECT_ID = process.env.NEXT_PUBLIC_STACK_PROJECT_ID;
+const PROJECT_ID = process.env.STACK_AUTH_PROJECT_ID;
 
 let jwks;
 
 async function getJWKS() {
   if (!jwks) {
     if (!PROJECT_ID) {
-      throw new Error('NEXT_PUBLIC_STACK_PROJECT_ID is not set');
+      throw new Error('STACK_AUTH_PROJECT_ID is not set');
     }
     const url = `${STACK_AUTH_BASE_URL}/api/v1/projects/${PROJECT_ID}/.well-known/jwks.json`;
     jwks = createRemoteJWKSet(new URL(url));


### PR DESCRIPTION
## Summary
- standardize on STACK_AUTH_PROJECT_ID for Stack Auth project identification
- document STACK_AUTH_PROJECT_ID and related auth env vars in AGENTS instructions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689746ab7d8883289c2f2fbe093558f0