### PR TITLE
feat: centralize session cookie parsing

### DIFF
--- a/api/auth/me.js
+++ b/api/auth/me.js
@@ -1,13 +1,12 @@
 const { verifyToken } = require('../../lib/auth');
+const { getSessionToken } = require('../../lib/cookies');
 
 module.exports = async (req, res) => {
   try {
-    const cookie = req.headers?.cookie || '';
-    const session = cookie.split(';').find(c => c.trim().startsWith('session='));
-    if (!session) {
+    const token = getSessionToken(req);
+    if (!token) {
       return res.status(401).json({ error: 'unauthorized' });
     }
-    const token = session.split('=')[1];
     const payload = await verifyToken(token);
     if (!payload) {
       return res.status(401).json({ error: 'unauthorized' });

--- a/api/posts/[id].js
+++ b/api/posts/[id].js
@@ -1,5 +1,6 @@
 const db = require('../../lib/db');
 const { verifyToken } = require('../../lib/auth');
+const { getSessionToken } = require('../../lib/cookies');
 
 module.exports = async (req, res) => {
   const id = req.query.id;
@@ -14,9 +15,7 @@ module.exports = async (req, res) => {
       return res.status(200).json(rows[0]);
     }
     if (req.method === 'PUT') {
-      const cookie = req.headers?.cookie || '';
-      const session = cookie.split(';').find(c => c.trim().startsWith('session='));
-      const token = session && session.split('=')[1];
+      const token = getSessionToken(req);
       const payload = token && await verifyToken(token);
       if (!payload) {
         return res.status(401).json({ error: 'unauthorized' });
@@ -39,9 +38,7 @@ module.exports = async (req, res) => {
       return res.status(200).json(rows[0]);
     }
     if (req.method === 'DELETE') {
-      const cookie = req.headers?.cookie || '';
-      const session = cookie.split(';').find(c => c.trim().startsWith('session='));
-      const token = session && session.split('=')[1];
+      const token = getSessionToken(req);
       const payload = token && await verifyToken(token);
       if (!payload) {
         return res.status(401).json({ error: 'unauthorized' });

--- a/api/posts/index.js
+++ b/api/posts/index.js
@@ -1,6 +1,7 @@
 // api/posts/index.js
 const { query } = require('../../lib/db');
 const { verifyToken } = require('../../lib/auth');
+const { getSessionToken } = require('../../lib/cookies');
 
 module.exports = async (req, res) => {
   try {
@@ -14,9 +15,7 @@ module.exports = async (req, res) => {
     }
 
     if (req.method === 'POST') {
-      const cookie = req.headers?.cookie || '';
-      const session = cookie.split(';').find(c => c.trim().startsWith('session='));
-      const token = session && session.split('=')[1];
+      const token = getSessionToken(req);
       const payload = token && await verifyToken(token);
       if (!payload) {
         return res.status(401).json({ error: 'unauthorized' });

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -1,0 +1,12 @@
+function getSessionToken(req) {
+  const cookieHeader = req?.headers?.cookie || '';
+  const session = cookieHeader
+    .split(';')
+    .map(c => c.trim())
+    .find(c => c.startsWith('session='));
+  if (!session) return null;
+  const token = session.slice('session='.length);
+  return token || null;
+}
+
+module.exports = { getSessionToken };

--- a/tests/cookies.test.js
+++ b/tests/cookies.test.js
@@ -1,0 +1,28 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { getSessionToken } = require('../lib/cookies');
+
+test('extracts session token from simple cookie string', () => {
+  const req = { headers: { cookie: 'session=abc123' } };
+  assert.strictEqual(getSessionToken(req), 'abc123');
+});
+
+test('extracts token when multiple cookies with spaces', () => {
+  const req = { headers: { cookie: 'foo=1; session=abc123; bar=2' } };
+  assert.strictEqual(getSessionToken(req), 'abc123');
+});
+
+test('returns null when session cookie missing', () => {
+  const req = { headers: { cookie: 'foo=1; bar=2' } };
+  assert.strictEqual(getSessionToken(req), null);
+});
+
+test('returns null when cookie header absent', () => {
+  const req = { headers: {} };
+  assert.strictEqual(getSessionToken(req), null);
+});
+
+test('returns null for empty session cookie', () => {
+  const req = { headers: { cookie: 'session=' } };
+  assert.strictEqual(getSessionToken(req), null);
+});


### PR DESCRIPTION
## Summary
- add `getSessionToken` helper for extracting session tokens from cookies
- use helper in auth and posts endpoints instead of manual parsing
- cover cookie parsing with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897493b1944832894115558b08263c7