### PR TITLE
Add admin authorization to post routes

### DIFF
--- a/api/posts/[id].js
+++ b/api/posts/[id].js
@@ -1,6 +1,5 @@
 const db = require('../../lib/db');
-const { verifyToken } = require('../../lib/auth');
-const { getSessionToken } = require('../../lib/cookies');
+const requireAdmin = require('../../lib/requireAdmin');
 
 module.exports = async (req, res) => {
   const id = req.query.id;
@@ -15,11 +14,8 @@ module.exports = async (req, res) => {
       return res.status(200).json(rows[0]);
     }
     if (req.method === 'PUT') {
-      const token = getSessionToken(req);
-      const payload = token && await verifyToken(token);
-      if (!payload) {
-        return res.status(401).json({ error: 'unauthorized' });
-      }
+      const admin = await requireAdmin(req, res);
+      if (!admin) return;
 
       let body;
       try {
@@ -38,11 +34,8 @@ module.exports = async (req, res) => {
       return res.status(200).json(rows[0]);
     }
     if (req.method === 'DELETE') {
-      const token = getSessionToken(req);
-      const payload = token && await verifyToken(token);
-      if (!payload) {
-        return res.status(401).json({ error: 'unauthorized' });
-      }
+      const admin = await requireAdmin(req, res);
+      if (!admin) return;
 
       const isNumeric = /^\d+$/.test(id);
       const query = isNumeric

--- a/api/posts/index.js
+++ b/api/posts/index.js
@@ -1,7 +1,6 @@
 // api/posts/index.js
 const { query } = require('../../lib/db');
-const { verifyToken } = require('../../lib/auth');
-const { getSessionToken } = require('../../lib/cookies');
+const requireAdmin = require('../../lib/requireAdmin');
 
 module.exports = async (req, res) => {
   try {
@@ -15,11 +14,8 @@ module.exports = async (req, res) => {
     }
 
     if (req.method === 'POST') {
-      const token = getSessionToken(req);
-      const payload = token && await verifyToken(token);
-      if (!payload) {
-        return res.status(401).json({ error: 'unauthorized' });
-      }
+      const admin = await requireAdmin(req, res);
+      if (!admin) return;
 
       const {
         title, slug,

--- a/lib/requireAdmin.js
+++ b/lib/requireAdmin.js
@@ -1,0 +1,21 @@
+const { verifyToken } = require('./auth');
+const { getSessionToken } = require('./cookies');
+const db = require('./db');
+
+module.exports = async function requireAdmin(req, res) {
+  const token = getSessionToken(req);
+  const payload = token && await verifyToken(token);
+  if (!payload) {
+    res.status(401).json({ error: 'unauthorized' });
+    return null;
+  }
+  const { sub } = payload;
+  const { rows } = await db.query('SELECT role FROM users WHERE id = $1', [sub]);
+  const role = rows[0] && rows[0].role;
+  if (role !== 'admin') {
+    res.status(403).json({ error: 'forbidden' });
+    return null;
+  }
+  req.user = { id: sub, role };
+  return req.user;
+};

--- a/tests/malformed-json.test.js
+++ b/tests/malformed-json.test.js
@@ -20,6 +20,12 @@ test('PUT /api/posts/:slug returns 400 for invalid JSON', async () => {
   )`);
   await pool.query(`INSERT INTO posts(slug, title) VALUES('test-slug', 'Old Title')`);
 
+  await pool.query(`CREATE TABLE users (
+    id SERIAL PRIMARY KEY,
+    role TEXT
+  )`);
+  await pool.query(`INSERT INTO users(role) VALUES('admin')`);
+
   const db = require('../lib/db');
   db.query = (text, params) => pool.query(text, params);
 

--- a/tests/posts-admin-forbidden.test.js
+++ b/tests/posts-admin-forbidden.test.js
@@ -1,0 +1,94 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+// Ensure non-admin users are forbidden
+
+test('POST /api/posts forbids non-admin users', async (t) => {
+  const db = require('../lib/db');
+  const originalQuery = db.query;
+  db.query = async (text, params) => {
+    if (text.includes('SELECT role FROM users')) {
+      return { rows: [{ role: 'user' }] };
+    }
+    throw new Error('should not query posts');
+  };
+  const auth = require('../lib/auth');
+  const originalVerify = auth.verifyToken;
+  auth.verifyToken = async () => ({ sub: '1' });
+  t.after(() => {
+    db.query = originalQuery;
+    auth.verifyToken = originalVerify;
+  });
+  const handler = require('../api/posts/index.js');
+  const req = { method: 'POST', headers: { cookie: 'session=valid' }, body: { title: 't', slug: 's' } };
+  let statusCode; let jsonBody;
+  const res = {
+    status(code) { statusCode = code; return this; },
+    json(data) { jsonBody = data; return this; },
+    setHeader() {},
+    end() {},
+  };
+  await handler(req, res);
+  assert.strictEqual(statusCode, 403);
+  assert.deepStrictEqual(jsonBody, { error: 'forbidden' });
+});
+
+test('PUT /api/posts/:id forbids non-admin users', async (t) => {
+  const db = require('../lib/db');
+  const originalQuery = db.query;
+  db.query = async (text, params) => {
+    if (text.includes('SELECT role FROM users')) {
+      return { rows: [{ role: 'user' }] };
+    }
+    throw new Error('should not query posts');
+  };
+  const auth = require('../lib/auth');
+  const originalVerify = auth.verifyToken;
+  auth.verifyToken = async () => ({ sub: '1' });
+  t.after(() => {
+    db.query = originalQuery;
+    auth.verifyToken = originalVerify;
+  });
+  const handler = require('../api/posts/[id].js');
+  const req = { method: 'PUT', query: { id: '1' }, headers: { cookie: 'session=valid' }, body: { title: 'x' } };
+  let statusCode; let jsonBody;
+  const res = {
+    status(code) { statusCode = code; return this; },
+    json(data) { jsonBody = data; return this; },
+    setHeader() {},
+    end() {},
+  };
+  await handler(req, res);
+  assert.strictEqual(statusCode, 403);
+  assert.deepStrictEqual(jsonBody, { error: 'forbidden' });
+});
+
+test('DELETE /api/posts/:id forbids non-admin users', async (t) => {
+  const db = require('../lib/db');
+  const originalQuery = db.query;
+  db.query = async (text, params) => {
+    if (text.includes('SELECT role FROM users')) {
+      return { rows: [{ role: 'user' }] };
+    }
+    throw new Error('should not query posts');
+  };
+  const auth = require('../lib/auth');
+  const originalVerify = auth.verifyToken;
+  auth.verifyToken = async () => ({ sub: '1' });
+  t.after(() => {
+    db.query = originalQuery;
+    auth.verifyToken = originalVerify;
+  });
+  const handler = require('../api/posts/[id].js');
+  const req = { method: 'DELETE', query: { id: '1' }, headers: { cookie: 'session=valid' } };
+  let statusCode; let jsonBody;
+  const res = {
+    status(code) { statusCode = code; return this; },
+    json(data) { jsonBody = data; return this; },
+    setHeader() {},
+    end() {},
+  };
+  await handler(req, res);
+  assert.strictEqual(statusCode, 403);
+  assert.deepStrictEqual(jsonBody, { error: 'forbidden' });
+});

--- a/tests/slug-update.test.js
+++ b/tests/slug-update.test.js
@@ -22,6 +22,12 @@ test('PUT /api/posts/:slug updates by slug', async () => {
   )`);
   await pool.query(`INSERT INTO posts(slug, title) VALUES('test-slug', 'Old Title')`);
 
+  await pool.query(`CREATE TABLE users (
+    id SERIAL PRIMARY KEY,
+    role TEXT
+  )`);
+  await pool.query(`INSERT INTO users(role) VALUES('admin')`);
+
   const db = require('../lib/db');
   db.query = (text, params) => pool.query(text, params);
 


### PR DESCRIPTION
## Summary
- add reusable `requireAdmin` middleware to gate actions behind admin role
- enforce admin checks on POST/PUT/DELETE post endpoints
- verify non-admin users receive 403 responses

## Testing
- `npm test`

