### PR TITLE
feat: add auth pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,8 +114,8 @@
           </div>
 
           <div id="auth-area" class="flex items-center gap-2">
-            <a id="login-link" href="/api/auth/login" class="px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Login</a>
-            <a id="signup-link" href="/api/auth/signup" class="px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Sign Up</a>
+            <a id="login-link" href="/login.html" class="px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Login</a>
+            <a id="signup-link" href="/signup.html" class="px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Sign Up</a>
             <div id="user-info" class="hidden items-center gap-2">
               <span id="user-name" class="font-medium"></span>
               <a id="admin-link" href="/admin.html" class="hidden px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Admin</a>

--- a/login.html
+++ b/login.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Login - AI News Hub</title>
+  <!-- Tailwind & Icons -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root{--primary:#0ea5e9;--secondary:#06b6d4;--dark:#0f172a;--light:#f8fafc;--accent:#818cf8;}
+    body{font-family:'Inter',sans-serif;background:#f8fafc;color:#0f172a;}
+  </style>
+</head>
+<body class="bg-light dark:bg-dark">
+  <main class="max-w-md mx-auto p-6">
+    <h1 class="text-2xl font-bold mb-6 text-center">Login</h1>
+    <form id="login-form" class="space-y-4">
+      <input id="email" type="email" placeholder="Email" class="w-full border rounded p-2" required />
+      <input id="password" type="password" placeholder="Password" class="w-full border rounded p-2" required />
+      <button type="submit" class="w-full bg-primary text-white px-4 py-2 rounded">Login</button>
+    </form>
+  </main>
+  <script>
+    function getCsrfToken(){
+      const m=document.cookie.match(/(?:^|;)\s*csrf=([^;]+)/);
+      if(!m) return '';
+      return decodeURIComponent(m[1]).split('.')[0];
+    }
+    document.addEventListener('DOMContentLoaded', async () => {
+      try { await fetch('/api/auth/login', { credentials: 'include' }); } catch (e) {}
+      const form=document.getElementById('login-form');
+      form.addEventListener('submit', async (e)=>{
+        e.preventDefault();
+        const email=document.getElementById('email').value.trim();
+        const password=document.getElementById('password').value;
+        const csrfToken=getCsrfToken();
+        const res=await fetch('/api/auth/login',{
+          method:'POST',
+          headers:{'Content-Type':'application/json','X-CSRF-Token':csrfToken},
+          credentials:'include',
+          body:JSON.stringify({email,password})
+        });
+        if(res.ok){
+          window.location.href='/';
+        }else{
+          alert('Login failed');
+        }
+      });
+    });
+  </script>
+</body>
+</html>

--- a/signup.html
+++ b/signup.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Sign Up - AI News Hub</title>
+  <!-- Tailwind & Icons -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root{--primary:#0ea5e9;--secondary:#06b6d4;--dark:#0f172a;--light:#f8fafc;--accent:#818cf8;}
+    body{font-family:'Inter',sans-serif;background:#f8fafc;color:#0f172a;}
+  </style>
+</head>
+<body class="bg-light dark:bg-dark">
+  <main class="max-w-md mx-auto p-6">
+    <h1 class="text-2xl font-bold mb-6 text-center">Sign Up</h1>
+    <form id="signup-form" class="space-y-4">
+      <input id="name" type="text" placeholder="Name" class="w-full border rounded p-2" required />
+      <input id="email" type="email" placeholder="Email" class="w-full border rounded p-2" required />
+      <input id="password" type="password" placeholder="Password" class="w-full border rounded p-2" required />
+      <button type="submit" class="w-full bg-primary text-white px-4 py-2 rounded">Create Account</button>
+    </form>
+  </main>
+  <script>
+    function getCsrfToken(){
+      const m=document.cookie.match(/(?:^|;)\s*csrf=([^;]+)/);
+      if(!m) return '';
+      return decodeURIComponent(m[1]).split('.')[0];
+    }
+    document.addEventListener('DOMContentLoaded', async () => {
+      try { await fetch('/api/auth/signup', { credentials: 'include' }); } catch (e) {}
+      const form=document.getElementById('signup-form');
+      form.addEventListener('submit', async (e)=>{
+        e.preventDefault();
+        const name=document.getElementById('name').value.trim();
+        const email=document.getElementById('email').value.trim();
+        const password=document.getElementById('password').value;
+        const csrfToken=getCsrfToken();
+        const res=await fetch('/api/auth/signup',{
+          method:'POST',
+          headers:{'Content-Type':'application/json','X-CSRF-Token':csrfToken},
+          credentials:'include',
+          body:JSON.stringify({name,email,password})
+        });
+        if(res.ok){
+          window.location.href='/';
+        }else{
+          alert('Signup failed');
+        }
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add dedicated login and signup pages with CSRF token handling
- link index page auth buttons to new pages

## Testing
- `npm test`

