### PR TITLE
Improve auth forms with inline errors and disabled submit

### DIFF
--- a/login.html
+++ b/login.html
@@ -34,27 +34,38 @@
       try { await fetch('/api/auth/login', { credentials: 'include' }); } catch (e) {}
       const form=document.getElementById('login-form');
       const errorEl=document.getElementById('error-message');
+      const btn=form.querySelector('button');
       form.addEventListener('submit', async (e)=>{
         e.preventDefault();
         errorEl.textContent='';
         const email=document.getElementById('email').value.trim();
         const password=document.getElementById('password').value;
         const csrfToken=getCsrfToken();
-        const res=await fetch('/api/auth/login',{
-          method:'POST',
-          headers:{'Content-Type':'application/json','X-CSRF-Token':csrfToken},
-          credentials:'include',
-          body:JSON.stringify({email,password})
-        });
-        if(res.ok){
-          window.location.href='/';
-        }else{
-          let msg='Login failed';
-          try{
-            const data=await res.json();
-            msg=data.error||msg;
-          }catch{}
-          errorEl.textContent=msg;
+        btn.disabled=true;
+        const originalHTML=btn.innerHTML;
+        btn.innerHTML='<i class="fas fa-spinner fa-spin mr-2"></i> Logging in...';
+        try{
+          const res=await fetch('/api/auth/login',{
+            method:'POST',
+            headers:{'Content-Type':'application/json','X-CSRF-Token':csrfToken},
+            credentials:'include',
+            body:JSON.stringify({email,password})
+          });
+          if(res.ok){
+            window.location.href='/';
+          }else{
+            let msg='Login failed';
+            try{
+              const data=await res.json();
+              msg=data.error||msg;
+            }catch{}
+            errorEl.textContent=msg;
+          }
+        }catch{
+          errorEl.textContent='Login failed';
+        }finally{
+          btn.disabled=false;
+          btn.innerHTML=originalHTML;
         }
       });
     });

--- a/signup.html
+++ b/signup.html
@@ -21,6 +21,7 @@
       <input id="email" type="email" placeholder="Email" class="w-full border rounded p-2" required />
       <input id="password" type="password" placeholder="Password" class="w-full border rounded p-2" required />
       <button type="submit" class="w-full bg-primary text-white px-4 py-2 rounded">Create Account</button>
+      <p id="error-message" class="text-red-600"></p>
     </form>
   </main>
   <script>
@@ -32,22 +33,40 @@
     document.addEventListener('DOMContentLoaded', async () => {
       try { await fetch('/api/auth/signup', { credentials: 'include' }); } catch (e) {}
       const form=document.getElementById('signup-form');
+      const errorEl=document.getElementById('error-message');
+      const btn=form.querySelector('button');
       form.addEventListener('submit', async (e)=>{
         e.preventDefault();
+        errorEl.textContent='';
         const name=document.getElementById('name').value.trim();
         const email=document.getElementById('email').value.trim();
         const password=document.getElementById('password').value;
         const csrfToken=getCsrfToken();
-        const res=await fetch('/api/auth/signup',{
-          method:'POST',
-          headers:{'Content-Type':'application/json','X-CSRF-Token':csrfToken},
-          credentials:'include',
-          body:JSON.stringify({name,email,password})
-        });
-        if(res.ok){
-          window.location.href='/';
-        }else{
-          alert('Signup failed');
+        btn.disabled=true;
+        const originalHTML=btn.innerHTML;
+        btn.innerHTML='<i class="fas fa-spinner fa-spin mr-2"></i> Creating...';
+        try{
+          const res=await fetch('/api/auth/signup',{
+            method:'POST',
+            headers:{'Content-Type':'application/json','X-CSRF-Token':csrfToken},
+            credentials:'include',
+            body:JSON.stringify({name,email,password})
+          });
+          if(res.ok){
+            window.location.href='/';
+          }else{
+            let msg='Signup failed';
+            try{
+              const data=await res.json();
+              msg=data.error||msg;
+            }catch{}
+            errorEl.textContent=msg;
+          }
+        }catch{
+          errorEl.textContent='Signup failed';
+        }finally{
+          btn.disabled=false;
+          btn.innerHTML=originalHTML;
         }
       });
     });


### PR DESCRIPTION
## Summary
- show inline error messages on signup
- disable submit buttons with spinners for login & signup
- display server error codes instead of alerts

## Testing
- `npm test`
