### PR TITLE
feat: add oauth callback and provider redirect

### DIFF
--- a/api/auth/callback.js
+++ b/api/auth/callback.js
@@ -1,0 +1,72 @@
+const db = require('../../lib/db');
+const { verifyToken, signJWT } = require('../../lib/auth');
+const { signSessionToken } = require('../../lib/cookies');
+
+module.exports = async (req, res) => {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({ error: 'method_not_allowed' });
+  }
+
+  try {
+    const { state, token } = req.query || {};
+    if (!state || !token) {
+      return res.status(400).json({ error: 'invalid_oauth_response' });
+    }
+
+    const cookies = Object.fromEntries((req.headers.cookie || '').split(';').filter(Boolean).map(c => {
+      const i = c.indexOf('=');
+      return [c.slice(0, i).trim(), decodeURIComponent(c.slice(i + 1))];
+    }));
+    const stateCookie = cookies.oauth_state;
+    const clearState = 'oauth_state=; Max-Age=0; HttpOnly; Secure; SameSite=Strict; Path=/';
+    if (!stateCookie || stateCookie !== state) {
+      res.setHeader('Set-Cookie', clearState);
+      return res.status(400).json({ error: 'invalid_oauth_response' });
+    }
+
+    let payload;
+    try {
+      payload = await verifyToken(token);
+    } catch (err) {
+      payload = null;
+    }
+    if (!payload || !payload.sub || !payload.name) {
+      res.setHeader('Set-Cookie', clearState);
+      return res.status(400).json({ error: 'invalid_oauth_response' });
+    }
+
+    const id = parseInt(payload.sub, 10);
+    if (Number.isNaN(id)) {
+      res.setHeader('Set-Cookie', clearState);
+      return res.status(400).json({ error: 'invalid_oauth_response' });
+    }
+    const name = payload.name || '';
+    const email = payload.email || '';
+
+    const { rows } = await db.query(
+      `INSERT INTO users(id, name, email, password_hash, role)
+       VALUES($1,$2,$3,'',$4)
+       ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name, email = EXCLUDED.email
+       RETURNING id, name, email, role`,
+      [id, name, email, 'user']
+    );
+    const user = rows[0];
+
+    const jwt = await signJWT({
+      sub: user.id.toString(),
+      email: user.email,
+      name: user.name,
+      role: user.role,
+    });
+    const signed = signSessionToken(jwt);
+    const sessionCookie = `session=${signed}; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=3600`;
+
+    res.setHeader('Set-Cookie', [sessionCookie, clearState]);
+    res.writeHead(302, { Location: '/' });
+    res.end();
+  } catch (err) {
+    console.error('/api/auth/callback error:', err);
+    return res.status(400).json({ error: 'invalid_oauth_response' });
+  }
+};

--- a/api/auth/oauth/[provider].js
+++ b/api/auth/oauth/[provider].js
@@ -1,0 +1,26 @@
+const crypto = require('node:crypto');
+
+module.exports = async (req, res) => {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({ error: 'method_not_allowed' });
+  }
+
+  const provider = req.query.provider;
+  if (!provider) {
+    return res.status(400).json({ error: 'missing_provider' });
+  }
+
+  const state = crypto.randomBytes(16).toString('hex');
+  const proto = req.headers['x-forwarded-proto'] || 'https';
+  const host = req.headers['x-forwarded-host'] || req.headers.host;
+  const baseUrl = `${proto}://${host}`;
+  const redirectUri = encodeURIComponent(`${baseUrl}/api/auth/callback`);
+  const clientId = process.env.STACK_AUTH_CLIENT_ID || '';
+  const url = `https://api.stack-auth.com/api/v1/oauth/authorize?provider=${encodeURIComponent(provider)}&client_id=${encodeURIComponent(clientId)}&redirect_uri=${redirectUri}&state=${state}`;
+
+  const cookie = `oauth_state=${state}; HttpOnly; Secure; SameSite=Strict; Max-Age=600; Path=/`;
+  res.setHeader('Set-Cookie', cookie);
+  res.writeHead(302, { Location: url });
+  res.end();
+};


### PR DESCRIPTION
## Summary
- redirect `/api/auth/oauth/[provider]` requests to Stack Auth with a CSRF state cookie
- handle `/api/auth/callback` to verify state and Neon Auth JWT, upsert users and issue session cookies
- return `400 invalid_oauth_response` on any OAuth errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897b67f92ac8328b7be2a66817376f6