### PR TITLE
Validate OAuth state on callback

### DIFF
--- a/api/auth/callback.js
+++ b/api/auth/callback.js
@@ -22,10 +22,12 @@ module.exports = async (req, res) => {
 
   try {
     const { state, token } = req.query || {};
-    if (!state || !token || stateCookie !== state) {
-      if (stateCookie) {
-        res.setHeader('Set-Cookie', clearState);
-      }
+    if (!state || !stateCookie || stateCookie !== state) {
+      res.setHeader('Set-Cookie', clearState);
+      return res.status(400).json({ error: 'invalid_state' });
+    }
+    if (!token) {
+      res.setHeader('Set-Cookie', clearState);
       return res.status(400).json({ error: 'invalid_oauth_response' });
     }
 


### PR DESCRIPTION
## Summary
- Ensure the OAuth callback verifies the `state` against the `oauth_state` cookie and rejects mismatches with `400 invalid_state`
- Clear the temporary `oauth_state` cookie after validation

## Testing
- `npm test`


