### PR TITLE
feat: add PKCE support for Stack Auth

### DIFF
--- a/api/auth/oauth/[provider].js
+++ b/api/auth/oauth/[provider].js
@@ -1,6 +1,15 @@
 const crypto = require('node:crypto');
 const { ensureConfig } = require('../../../lib/auth');
 
+// helper: base64url (RFC 4648 §5)
+function b64url(buf) {
+  return buf
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '');
+}
+
 module.exports = async (req, res) => {
   if (req.method !== 'GET') {
     res.setHeader('Allow', 'GET');
@@ -18,16 +27,41 @@ module.exports = async (req, res) => {
     const proto = req.headers['x-forwarded-proto'] || 'https';
     const host = req.headers['x-forwarded-host'] || req.headers.host;
     const baseUrl = `${proto}://${host}`;
-    const redirectUri = encodeURIComponent(`${baseUrl}/api/auth/callback`);
-    const clientId = process.env.STACK_AUTH_CLIENT_ID || '';
-    const url =
-      `https://api.stack-auth.com/api/v1/oauth/authorize?provider=${encodeURIComponent(
-        provider
-      )}&client_id=${encodeURIComponent(clientId)}&redirect_uri=${redirectUri}&state=${state}`;
+    const redirectUri = `${baseUrl}/api/auth/callback`;
 
-    const cookie = `oauth_state=${state}; HttpOnly; Secure; SameSite=Strict; Max-Age=600; Path=/`;
-    res.setHeader('Set-Cookie', cookie);
-    res.writeHead(302, { Location: url });
+    // ⚠️ NEW: PKCE
+    const codeVerifier = b64url(crypto.randomBytes(32));
+    const codeChallenge = b64url(
+      crypto.createHash('sha256').update(codeVerifier).digest()
+    );
+
+    // store verifier in a short‑lived, HttpOnly cookie for the callback to read
+    const pkceCookie =
+      `pkce_verifier=${codeVerifier}; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=600`;
+
+    // your Stack Auth project + publishable key
+    const projectId = process.env.NEXT_PUBLIC_STACK_PROJECT_ID || '';
+    const publishableId = process.env.STACK_AUTH_CLIENT_ID || '';
+
+    const url = new URL(
+      `https://api.stack-auth.com/api/v1/auth/oauth/authorize/${encodeURIComponent(
+        provider
+      )}`
+    );
+    url.searchParams.set('client_id', projectId);
+    url.searchParams.set('client_secret', publishableId);
+    url.searchParams.set('redirect_uri', redirectUri);
+    url.searchParams.set('response_type', 'code');
+    url.searchParams.set('grant_type', 'authorization_code');
+    url.searchParams.set('scope', 'openid email profile');
+    url.searchParams.set('code_challenge_method', 'S256');
+    url.searchParams.set('code_challenge', codeChallenge);
+    url.searchParams.set('state', state);
+
+    const cookie =
+      `oauth_state=${state}; HttpOnly; Secure; SameSite=Strict; Max-Age=600; Path=/`;
+    res.setHeader('Set-Cookie', [pkceCookie, cookie]);
+    res.writeHead(302, { Location: url.toString() });
     res.end();
   } catch (err) {
     console.error('/api/auth/oauth/[provider] error:', err);


### PR DESCRIPTION
## Summary
- add PKCE helper, challenge, and verifier cookie in Stack Auth OAuth route
- include PKCE code_verifier when exchanging auth code for tokens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68988b75b13c8328bf3229d08406b57d