### PR TITLE
Redirect login route to Google OAuth

### DIFF
--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -10,10 +10,19 @@ const limiter = createRateLimiter({ windowMs: 15 * 60 * 1000, max: 5 });
 module.exports = async (req, res) => {
   try {
     ensureConfig();
-    ensureCsrf(req, res);
+
+    if (req.method === 'GET') {
+      res.writeHead(302, { Location: '/api/auth/oauth/google' });
+      res.end();
+      return;
+    }
+
     if (req.method !== 'POST') {
+      res.setHeader('Allow', 'GET, POST');
       return res.status(405).json({ error: 'method_not_allowed' });
     }
+
+    ensureCsrf(req, res);
 
     if (!validateCsrf(req)) {
       return res.status(403).json({ error: 'invalid_csrf_token' });

--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
           </div>
 
           <div id="auth-area" class="flex items-center gap-2">
-            <a id="login-link" href="/login.html" class="px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Login</a>
+            <a id="login-link" href="/api/auth/oauth/google" class="px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Login</a>
             <a id="signup-link" href="/signup.html" class="px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Sign Up</a>
             <div id="user-info" class="hidden items-center gap-2">
               <span id="user-name" class="font-medium"></span>


### PR DESCRIPTION
## Summary
- Redirect GET /api/auth/login to /api/auth/oauth/google
- Point login link directly to Google OAuth

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898915649708328b87981ee85686823