### PR TITLE
Redirect login route to Google OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,15 +75,8 @@ curl -X POST http://localhost:3000/api/auth/signup \
 ```
 
 ### Log In
-Refresh the CSRF token and capture the session cookie:
-```bash
-CSRF=$(grep csrf cookies.txt | awk '{print $7}')
-curl -X POST http://localhost:3000/api/auth/login \
-  -H "Content-Type: application/json" \
-  -H "X-CSRF-Token: $CSRF" \
-  -d '{"email":"alice@example.com","password":"password123"}' \
-  -b cookies.txt -c cookies.txt
-```
+Navigate your browser to `/api/auth/login` to be redirected to the Google OAuth
+flow. After completing consent, you'll be returned with a session cookie set.
 
 ### Admin-only Request
 
@@ -130,7 +123,7 @@ in your environment so the cookie cannot be tampered with.
 
 ## CSRF protection
 
-Mutation endpoints (`/api/auth/login`, `/api/auth/signup`, `/api/comments`, and `/api/admin/*` routes)
+Mutation endpoints (`/api/auth/signup`, `/api/comments`, and `/api/admin/*` routes)
 require a valid CSRF token. A random token is issued in a `csrf` cookie that is
 signed with `SESSION_SECRET`. Clients must echo the token in the `X-CSRF-Token`
 header when making POST/PUT/DELETE requests.

--- a/admin.html
+++ b/admin.html
@@ -59,9 +59,9 @@
     }
 
     async function ensureCsrfCookie() {
-      if (!getCsrfToken()) {
-        await fetch('/api/auth/login', { credentials: 'include' });
-      }
+        if (!getCsrfToken()) {
+          await fetch('/api/auth/signup', { credentials: 'include' });
+        }
     }
 
     function csrfFetch(url, options = {}) {

--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -1,75 +1,8 @@
-const db = require('../../lib/db');
-const bcrypt = require('bcryptjs');
-const { signJWT, ensureConfig } = require('../../lib/auth');
-const { signSessionToken } = require('../../lib/cookies');
-const { ensureCsrf, validateCsrf } = require('../../lib/csrf');
-const { createRateLimiter } = require('../../lib/rateLimit');
-
-const limiter = createRateLimiter({ windowMs: 15 * 60 * 1000, max: 5 });
-
-module.exports = async (req, res) => {
-  try {
-    ensureConfig();
-    ensureCsrf(req, res);
-    if (req.method !== 'POST') {
-      return res.status(405).json({ error: 'method_not_allowed' });
-    }
-
-    if (!validateCsrf(req)) {
-      return res.status(403).json({ error: 'invalid_csrf_token' });
-    }
-
-    const { email, password } = req.body || {};
-    if (!email || !password) {
-      return res.status(400).json({ error: 'missing_credentials' });
-    }
-
-    const ip = (req.headers['x-forwarded-for'] || '').split(',')[0] || req.socket?.remoteAddress || '';
-    if (limiter.isLimited(ip, email)) {
-      return res.status(429).json({ error: 'too_many_attempts' });
-    }
-
-    const { rows } = await db.query(
-      'SELECT id, name, email, password_hash, role FROM users WHERE email = $1',
-      [email]
-    );
-    if (rows.length === 0) {
-      limiter.recordFailure(ip, email);
-      return res.status(401).json({ error: 'invalid_credentials' });
-    }
-    const user = rows[0];
-    const valid = await bcrypt.compare(password, user.password_hash);
-    if (!valid) {
-      limiter.recordFailure(ip, email);
-      return res.status(401).json({ error: 'invalid_credentials' });
-    }
-
-    const token = await signJWT({
-      sub: user.id.toString(),
-      email: user.email,
-      name: user.name,
-      role: user.role,
-    });
-    const maxAge = 3600;
-    const signed = signSessionToken(token);
-    const cookie = `session=${signed}; HttpOnly; Secure; SameSite=Strict; Max-Age=${maxAge}; Path=/`;
-    const existing = res.getHeader && res.getHeader('Set-Cookie');
-    if (existing) {
-      if (Array.isArray(existing)) {
-        res.setHeader('Set-Cookie', [...existing, cookie]);
-      } else {
-        res.setHeader('Set-Cookie', [existing, cookie]);
-      }
-    } else {
-      res.setHeader('Set-Cookie', cookie);
-    }
-    limiter.clear(ip, email);
-    return res.status(200).json({ id: user.id, name: user.name, email: user.email, role: user.role });
-  } catch (err) {
-    console.error('/api/auth/login error:', err);
-    if (err.code === 'CONFIG_ERROR') {
-      return res.status(500).json({ error: 'missing_config' });
-    }
-    return res.status(500).json({ error: 'SERVER_ERROR' });
+module.exports = (req, res) => {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({ error: 'method_not_allowed' });
   }
+  res.writeHead(302, { Location: '/api/auth/oauth/google' });
+  res.end();
 };

--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
           </div>
 
           <div id="auth-area" class="flex items-center gap-2">
-            <a id="login-link" href="/login.html" class="px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Login</a>
+            <a id="login-link" href="/api/auth/oauth/google" class="px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Login</a>
             <a id="signup-link" href="/signup.html" class="px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Sign Up</a>
             <div id="user-info" class="hidden items-center gap-2">
               <span id="user-name" class="font-medium"></span>

--- a/login.html
+++ b/login.html
@@ -1,85 +1,16 @@
 <!DOCTYPE html>
-<html lang="en" class="scroll-smooth">
+<html lang="en">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Login - AI News Hub</title>
-  <!-- Tailwind & Icons -->
   <script src="https://cdn.tailwindcss.com"></script>
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-  <style>
-    :root{--primary:#0ea5e9;--secondary:#06b6d4;--dark:#0f172a;--light:#f8fafc;--accent:#818cf8;}
-    body{font-family:'Inter',sans-serif;background:#f8fafc;color:#0f172a;}
-  </style>
 </head>
 <body class="bg-light dark:bg-dark">
-  <main class="max-w-md mx-auto p-6">
-    <h1 class="text-2xl font-bold mb-6 text-center">Login</h1>
-    <form id="login-form" class="space-y-4">
-      <input id="email" type="email" placeholder="Email" class="w-full border rounded p-2" required />
-      <input id="password" type="password" placeholder="Password" class="w-full border rounded p-2" required />
-      <button type="submit" class="w-full bg-primary text-white px-4 py-2 rounded">Login</button>
-      <p id="error-message" class="text-red-600"></p>
-    </form>
-    <div class="mt-6 space-y-2">
-      <button data-oauth="/api/auth/oauth/google" class="w-full bg-red-500 text-white px-4 py-2 rounded flex items-center justify-center gap-2"><i class="fab fa-google"></i> Sign in with Google</button>
-      <button data-oauth="/api/auth/oauth/github" class="w-full bg-gray-800 text-white px-4 py-2 rounded flex items-center justify-center gap-2"><i class="fab fa-github"></i> Sign in with GitHub</button>
-    </div>
-    <p class="mt-4 text-center"><a href="/signup.html" class="text-primary">Create an account</a></p>
+  <main class="max-w-md mx-auto p-6 text-center">
+    <h1 class="text-2xl font-bold mb-6">Login</h1>
+    <a href="/api/auth/oauth/google" class="block w-full bg-primary text-white px-4 py-2 rounded mb-4">Login with Google</a>
+    <a href="/api/auth/oauth/github" class="block w-full bg-gray-800 text-white px-4 py-2 rounded">Login with GitHub</a>
   </main>
-  <script>
-    function getCsrfToken(){
-      const m=document.cookie.match(/(?:^|;)\s*csrf=([^;]+)/);
-      if(!m) return '';
-      return decodeURIComponent(m[1]).split('.')[0];
-    }
-    document.addEventListener('DOMContentLoaded', async () => {
-      try { await fetch('/api/auth/login', { credentials: 'include' }); } catch (e) {}
-      const form=document.getElementById('login-form');
-      const errorEl=document.getElementById('error-message');
-      const btn=form.querySelector('button');
-      document.querySelectorAll('[data-oauth]').forEach(o=>{
-        o.addEventListener('click',()=>{
-          o.disabled=true;
-          o.innerHTML='<i class="fas fa-spinner fa-spin mr-2"></i> Redirecting...';
-          window.location.href=o.dataset.oauth;
-        });
-      });
-      form.addEventListener('submit', async (e)=>{
-        e.preventDefault();
-        errorEl.textContent='';
-        const email=document.getElementById('email').value.trim();
-        const password=document.getElementById('password').value;
-        const csrfToken=getCsrfToken();
-        btn.disabled=true;
-        const originalHTML=btn.innerHTML;
-        btn.innerHTML='<i class="fas fa-spinner fa-spin mr-2"></i> Logging in...';
-        try{
-          const res=await fetch('/api/auth/login',{
-            method:'POST',
-            headers:{'Content-Type':'application/json','X-CSRF-Token':csrfToken},
-            credentials:'include',
-            body:JSON.stringify({email,password})
-          });
-          if(res.ok){
-            window.location.href='/';
-          }else{
-            let msg='Login failed';
-            try{
-              const data=await res.json();
-              msg=data.error||msg;
-            }catch{}
-            errorEl.textContent=msg;
-          }
-        }catch{
-          errorEl.textContent='Login failed';
-        }finally{
-          btn.disabled=false;
-          btn.innerHTML=originalHTML;
-        }
-      });
-    });
-  </script>
 </body>
 </html>

--- a/post.html
+++ b/post.html
@@ -30,9 +30,9 @@
     }
 
     async function ensureCsrfCookie() {
-      if (!getCsrfToken()) {
-        await fetch('/api/auth/login', { credentials: 'include' });
-      }
+        if (!getCsrfToken()) {
+          await fetch('/api/auth/signup', { credentials: 'include' });
+        }
     }
 
     function csrfFetch(url, options = {}) {

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -51,51 +51,20 @@ test('POST /api/auth/signup creates user with hashed password', async () => {
 
 // Login route
 
-test('POST /api/auth/login authenticates and sets cookie', async () => {
-  process.env.JWT_SECRET = 'testsecret';
-  process.env.SESSION_SECRET = 'cookiesecret';
-  delete require.cache[require.resolve('../lib/csrf')];
-  const { newDb } = require('pg-mem');
-  const mem = newDb();
-  const pg = mem.adapters.createPg();
-  const pool = new pg.Pool();
-  await pool.query(`CREATE TABLE users (
-    id SERIAL PRIMARY KEY,
-    name TEXT NOT NULL,
-    email TEXT UNIQUE NOT NULL,
-    password_hash TEXT NOT NULL,
-    role TEXT DEFAULT 'user'
-  )`);
-  const bcrypt = require('bcryptjs');
-  const hash = await bcrypt.hash('pw', 10);
-  await pool.query(`INSERT INTO users(name,email,password_hash,role) VALUES('Alice','a@b.c',$1,'user')`, [hash]);
-
-  const db = require('../lib/db');
-  db.query = (text, params) => pool.query(text, params);
-
+test('GET /api/auth/login redirects to Google OAuth', async () => {
   const handler = require('../api/auth/login.js');
-  const { signCsrfToken } = require('../lib/csrf');
-  const csrfToken = 't2';
-  const csrfCookie = `csrf=${signCsrfToken(csrfToken)}`;
-  const req = { method: 'POST', body: { email: 'a@b.c', password: 'pw' }, headers: { cookie: csrfCookie, 'x-csrf-token': csrfToken } };
-  let statusCode; let jsonBody; const headers = {};
+  const req = { method: 'GET' };
+  let statusCode; let headers = {};
   const res = {
-    status(code) { statusCode = code; return this; },
-    json(data) { jsonBody = data; return this; },
-    setHeader(k,v){ headers[k]=v; },
-    getHeader(k){ return headers[k]; },
+    writeHead(code, h) { statusCode = code; headers = h; return this; },
     end() {},
+    setHeader() {},
+    status(code) { statusCode = code; return this; },
+    json() {},
   };
   await handler(req, res);
-  assert.strictEqual(statusCode, 200);
-  const setCookie = Array.isArray(headers['Set-Cookie']) ? headers['Set-Cookie'] : [headers['Set-Cookie']];
-  assert.ok(setCookie.some(c => c.includes('session=')));
-  const sessionCookie = setCookie.find(c => c.includes('session='));
-  assert.match(sessionCookie, /HttpOnly/);
-  assert.match(sessionCookie, /Secure/);
-  assert.match(sessionCookie, /SameSite=Strict/);
-  assert.match(sessionCookie, /Path=\//);
-  assert.strictEqual(jsonBody.email, 'a@b.c');
+  assert.strictEqual(statusCode, 302);
+  assert.strictEqual(headers.Location, '/api/auth/oauth/google');
 });
 
 // Logout route


### PR DESCRIPTION
## Summary
- Redirect GET /api/auth/login to Google OAuth
- Remove POST-based login flows and use direct OAuth links
- Document and test the new redirect behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898915649708328b87981ee85686823