### PR TITLE
Require Stack project env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,11 @@
 DATABASE_URL=postgres://...
+
+# Publishable client key from Stack Auth (pck_...)
+STACK_AUTH_CLIENT_ID=
+
+# Stack project ID used to derive JWKS_URL
+STACK_PROJECT_ID=
+
 JWKS_URL=https://api.stack-auth.com/api/v1/projects/<project_id>/.well-known/jwks.json
 JWT_SECRET=...
 SESSION_SECRET=...

--- a/api/auth/callback.js
+++ b/api/auth/callback.js
@@ -41,7 +41,7 @@ module.exports = async (req, res) => {
     const host = req.headers['x-forwarded-host'] || req.headers.host;
     const baseUrl = `${proto}://${host}`;
 
-    const projectId = process.env.NEXT_PUBLIC_STACK_PROJECT_ID;
+    const projectId = process.env.STACK_PROJECT_ID;
     const serverSecret = process.env.STACK_SECRET_KEY;
 
     const tokenRes = await fetch(

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,8 +1,10 @@
 const { createRemoteJWKSet, jwtVerify, SignJWT } = require('jose');
 
 const REQUIRED_KEYS = [
+  'DATABASE_URL',
+  'STACK_PROJECT_ID',
   'STACK_AUTH_CLIENT_ID',
-  'NEXT_PUBLIC_STACK_PROJECT_ID',
+  'JWKS_URL',
   'JWT_SECRET',
   'SESSION_SECRET',
 ];

--- a/tests/auth-me.test.js
+++ b/tests/auth-me.test.js
@@ -2,9 +2,10 @@ const test = require('node:test');
 const assert = require('node:assert');
 
 const originalEnv = { ...process.env };
-process.env.NEXT_PUBLIC_STACK_PROJECT_ID = 'proj';
+process.env.STACK_PROJECT_ID = 'proj';
 process.env.STACK_AUTH_CLIENT_ID = 'client';
 process.env.STACK_SECRET_KEY = 'stacksecret';
+process.env.JWKS_URL = 'https://example.com/jwks.json';
 process.env.DATABASE_URL = 'postgres://localhost/test';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret';
 process.env.SESSION_SECRET = process.env.SESSION_SECRET || 'cookiesecret';

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -3,9 +3,10 @@ const assert = require('node:assert');
 
 const originalEnv = { ...process.env };
 
-process.env.NEXT_PUBLIC_STACK_PROJECT_ID = 'proj';
+process.env.STACK_PROJECT_ID = 'proj';
 process.env.STACK_AUTH_CLIENT_ID = 'client';
 process.env.STACK_SECRET_KEY = 'stacksecret';
+process.env.JWKS_URL = 'https://example.com/jwks.json';
 process.env.DATABASE_URL = 'postgres://localhost/test';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret';
 process.env.SESSION_SECRET = process.env.SESSION_SECRET || 'cookiesecret';

--- a/tests/comments-auth.test.js
+++ b/tests/comments-auth.test.js
@@ -3,9 +3,10 @@ const assert = require('node:assert');
 
 const originalEnv = { ...process.env };
 
-process.env.NEXT_PUBLIC_STACK_PROJECT_ID = 'proj';
+process.env.STACK_PROJECT_ID = 'proj';
 process.env.STACK_AUTH_CLIENT_ID = 'client';
 process.env.STACK_SECRET_KEY = 'stacksecret';
+process.env.JWKS_URL = 'https://example.com/jwks.json';
 process.env.DATABASE_URL = 'postgres://localhost/test';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret';
 process.env.SESSION_SECRET = process.env.SESSION_SECRET || 'cookiesecret';

--- a/tests/comments-delete.test.js
+++ b/tests/comments-delete.test.js
@@ -3,9 +3,10 @@ const assert = require('node:assert');
 
 const originalEnv = { ...process.env };
 
-process.env.NEXT_PUBLIC_STACK_PROJECT_ID = 'proj';
+process.env.STACK_PROJECT_ID = 'proj';
 process.env.STACK_AUTH_CLIENT_ID = 'client';
 process.env.STACK_SECRET_KEY = 'stacksecret';
+process.env.JWKS_URL = 'https://example.com/jwks.json';
 process.env.DATABASE_URL = 'postgres://localhost/test';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret';
 process.env.SESSION_SECRET = process.env.SESSION_SECRET || 'cookiesecret';

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -4,9 +4,10 @@ const assert = require('node:assert');
 const originalEnv = { ...process.env };
 
 test('health endpoint returns 500 when config missing', async () => {
-  process.env.NEXT_PUBLIC_STACK_PROJECT_ID = 'proj';
+  process.env.STACK_PROJECT_ID = 'proj';
   process.env.JWT_SECRET = 'secret';
   process.env.SESSION_SECRET = 'sess';
+  process.env.JWKS_URL = 'https://example.com/jwks.json';
   process.env.DATABASE_URL = 'postgres://localhost/test';
   delete process.env.STACK_AUTH_CLIENT_ID;
   delete require.cache[require.resolve('../lib/auth')];

--- a/tests/malformed-json.test.js
+++ b/tests/malformed-json.test.js
@@ -3,9 +3,10 @@ const assert = require('node:assert');
 const { newDb } = require('pg-mem');
 
 const originalEnv = { ...process.env };
-process.env.NEXT_PUBLIC_STACK_PROJECT_ID = 'proj';
+process.env.STACK_PROJECT_ID = 'proj';
 process.env.STACK_AUTH_CLIENT_ID = 'client';
 process.env.STACK_SECRET_KEY = 'stacksecret';
+process.env.JWKS_URL = 'https://example.com/jwks.json';
 process.env.DATABASE_URL = 'postgres://localhost/test';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret';
 process.env.SESSION_SECRET = process.env.SESSION_SECRET || 'cookiesecret';

--- a/tests/posts-admin-forbidden.test.js
+++ b/tests/posts-admin-forbidden.test.js
@@ -2,9 +2,10 @@ const test = require('node:test');
 const assert = require('node:assert');
 
 const originalEnv = { ...process.env };
-process.env.NEXT_PUBLIC_STACK_PROJECT_ID = 'proj';
+process.env.STACK_PROJECT_ID = 'proj';
 process.env.STACK_AUTH_CLIENT_ID = 'client';
 process.env.STACK_SECRET_KEY = 'stacksecret';
+process.env.JWKS_URL = 'https://example.com/jwks.json';
 process.env.DATABASE_URL = 'postgres://localhost/test';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret';
 process.env.SESSION_SECRET = process.env.SESSION_SECRET || 'cookiesecret';

--- a/tests/posts-auth-required.test.js
+++ b/tests/posts-auth-required.test.js
@@ -2,9 +2,10 @@ const test = require('node:test');
 const assert = require('node:assert');
 
 const originalEnv = { ...process.env };
-process.env.NEXT_PUBLIC_STACK_PROJECT_ID = 'proj';
+process.env.STACK_PROJECT_ID = 'proj';
 process.env.STACK_AUTH_CLIENT_ID = 'client';
 process.env.STACK_SECRET_KEY = 'stacksecret';
+process.env.JWKS_URL = 'https://example.com/jwks.json';
 process.env.DATABASE_URL = 'postgres://localhost/test';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret';
 process.env.SESSION_SECRET = process.env.SESSION_SECRET || 'cookiesecret';

--- a/tests/slug-update.test.js
+++ b/tests/slug-update.test.js
@@ -3,9 +3,10 @@ const assert = require('node:assert');
 const { newDb } = require('pg-mem');
 
 const originalEnv = { ...process.env };
-process.env.NEXT_PUBLIC_STACK_PROJECT_ID = 'proj';
+process.env.STACK_PROJECT_ID = 'proj';
 process.env.STACK_AUTH_CLIENT_ID = 'client';
 process.env.STACK_SECRET_KEY = 'stacksecret';
+process.env.JWKS_URL = 'https://example.com/jwks.json';
 process.env.DATABASE_URL = 'postgres://localhost/test';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret';
 process.env.SESSION_SECRET = process.env.SESSION_SECRET || 'cookiesecret';


### PR DESCRIPTION
## Summary
- enforce presence of Stack project and database env vars
- document STACK_AUTH_CLIENT_ID and STACK_PROJECT_ID in example env file
- adapt auth callback and tests to new configuration keys

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898eed90c7c832882ff14b69ed3ca54