### PR TITLE
refactor auth config handling for explicit env vars

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 - Dateien: `api/**`
 - DB: Postgres (Neon), Tabelle `public.posts`
 - Spalten (wichtig): id, slug (unique), title, excerpt, content, category, tags text[], author, image_url, published_at timestamptz default now()
-- ENV: `DATABASE_URL` (SSL), `STACK_AUTH_PROJECT_ID`, `STACK_AUTH_CLIENT_ID`
+- ENV: `DATABASE_URL` (SSL), `STACK_PROJECT_ID`, `STACK_AUTH_CLIENT_ID`, `STACK_SECRET_KEY`
 
 ## Regeln
 - Keine breaking Schema-Änderungen ohne Migration

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ Replace `example@domain.com` with the email of the account you want to promote.
 1. In the Neon Console, enable the **Google** and **GitHub** providers.
 2. Set the following environment variables:
    - `JWKS_URL` – `https://api.stack-auth.com/api/v1/projects/<project_id>/.well-known/jwks.json`
-   - `STACK_AUTH_PROJECT_ID` – your Neon Auth project ID.
-   - `STACK_AUTH_CLIENT_ID` – OAuth client ID from Neon Auth.
-   - `STACK_AUTH_CLIENT_SECRET` – OAuth client secret from Neon Auth.
+   - `STACK_PROJECT_ID` – your Stack project ID.
+   - `STACK_AUTH_CLIENT_ID` – OAuth client ID from Stack Auth.
+   - `STACK_SECRET_KEY` – OAuth client secret from Stack Auth.
 3. Add trusted domains in Neon Auth:
    - `http://localhost:3000`
    - Your production URL

--- a/api/auth/callback.js
+++ b/api/auth/callback.js
@@ -25,7 +25,7 @@ module.exports = async (req, res) => {
     'pkce_verifier=; Max-Age=0; HttpOnly; Secure; SameSite=Strict; Path=/';
 
   try {
-    ensureConfig();
+    ensureConfig(['STACK_PROJECT_ID', 'STACK_SECRET_KEY', 'JWKS_URL', 'JWT_SECRET']);
     const { state, code, provider } = req.query || {};
     console.log('/api/auth/callback: provider', provider);
     if (!state || !stateCookie || stateCookie !== state) {

--- a/api/auth/logout.js
+++ b/api/auth/logout.js
@@ -2,7 +2,7 @@ const { ensureConfig } = require('../../lib/auth');
 
 module.exports = (req, res) => {
   try {
-    ensureConfig();
+    ensureConfig(['SESSION_SECRET']);
     res.setHeader('Set-Cookie', 'session=; HttpOnly; Secure; SameSite=Strict; Max-Age=0; Path=/');
     res.writeHead(302, { Location: '/' }).end();
   } catch (err) {

--- a/api/auth/me.js
+++ b/api/auth/me.js
@@ -4,7 +4,7 @@ const db = require('../../lib/db');
 
 module.exports = async (req, res) => {
   try {
-    ensureConfig();
+    ensureConfig(['JWKS_URL', 'JWT_SECRET']);
     const token = getSessionToken(req);
     if (!token) {
       return res.status(401).json({ error: 'unauthorized' });

--- a/api/auth/oauth/[provider].js
+++ b/api/auth/oauth/[provider].js
@@ -13,7 +13,7 @@ module.exports = async (req, res) => {
   }
 
   try {
-    ensureConfig();
+    ensureConfig(['STACK_AUTH_CLIENT_ID']);
 
     const provider = req.query.provider;
     if (!provider) return res.status(400).json({ error: 'missing_provider' });
@@ -24,9 +24,6 @@ module.exports = async (req, res) => {
     const redirectUri = `${baseUrl}/api/auth/callback`;
 
     const clientId = process.env.STACK_AUTH_CLIENT_ID;
-    if (!clientId) {
-      return res.status(500).json({ error: 'server_config_error' });
-    }
 
     const verifier = b64url(crypto.randomBytes(32));
     const challenge = b64url(crypto.createHash('sha256').update(verifier).digest());

--- a/api/auth/signup.js
+++ b/api/auth/signup.js
@@ -8,7 +8,7 @@ const limiter = createRateLimiter({ windowMs: 10 * 60 * 1000, max: 5 });
 
 module.exports = async (req, res) => {
   try {
-    ensureConfig();
+    ensureConfig(['DATABASE_URL']);
     ensureCsrf(req, res);
     if (req.method !== 'POST') {
       return res.status(405).json({ error: 'method_not_allowed' });

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,12 +1,11 @@
 const { createRemoteJWKSet, jwtVerify, SignJWT } = require('jose');
 
+// Backward-compat default. New code should pass explicit keys.
 const REQUIRED_KEYS = [
   'DATABASE_URL',
-  'STACK_AUTH_PROJECT_ID',
+  'STACK_PROJECT_ID',
   'STACK_AUTH_CLIENT_ID',
-  'STACK_AUTH_CLIENT_SECRET',
-  'JWKS_URL',
-  'JWT_SECRET',
+  'STACK_SECRET_KEY',
   'SESSION_SECRET',
 ];
 
@@ -17,10 +16,26 @@ class ConfigError extends Error {
   }
 }
 
-function ensureConfig() {
-  const missingKeys = REQUIRED_KEYS.filter((k) => !process.env[k]);
-  if (missingKeys.length) {
-    throw new ConfigError(missingKeys);
+function ensureConfig(required = REQUIRED_KEYS) {
+  const keys = required && required.length ? [...required] : REQUIRED_KEYS;
+  const missing = [];
+
+  // Special case: allow JWKS_URL or JWT_SECRET
+  if (keys.includes('JWKS_URL') && keys.includes('JWT_SECRET')) {
+    if (!process.env.JWKS_URL && !process.env.JWT_SECRET) {
+      missing.push('JWKS_URL or JWT_SECRET');
+    }
+    // Remove them from individual checks
+    keys.splice(keys.indexOf('JWKS_URL'), 1);
+    keys.splice(keys.indexOf('JWT_SECRET'), 1);
+  }
+
+  for (const k of keys) {
+    if (!process.env[k]) missing.push(k);
+  }
+
+  if (missing.length) {
+    throw new ConfigError(missing);
   }
   return true;
 }

--- a/tests/auth-me.test.js
+++ b/tests/auth-me.test.js
@@ -2,9 +2,9 @@ const test = require('node:test');
 const assert = require('node:assert');
 
 const originalEnv = { ...process.env };
-process.env.STACK_AUTH_PROJECT_ID = 'proj';
+process.env.STACK_PROJECT_ID = 'proj';
 process.env.STACK_AUTH_CLIENT_ID = 'client';
-process.env.STACK_AUTH_CLIENT_SECRET = 'stacksecret';
+process.env.STACK_SECRET_KEY = 'stacksecret';
 process.env.JWKS_URL = 'https://example.com/jwks.json';
 process.env.DATABASE_URL = 'postgres://localhost/test';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret';

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -3,9 +3,9 @@ const assert = require('node:assert');
 
 const originalEnv = { ...process.env };
 
-process.env.STACK_AUTH_PROJECT_ID = 'proj';
+process.env.STACK_PROJECT_ID = 'proj';
 process.env.STACK_AUTH_CLIENT_ID = 'client';
-process.env.STACK_AUTH_CLIENT_SECRET = 'stacksecret';
+process.env.STACK_SECRET_KEY = 'stacksecret';
 process.env.JWKS_URL = 'https://example.com/jwks.json';
 process.env.DATABASE_URL = 'postgres://localhost/test';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret';

--- a/tests/comments-auth.test.js
+++ b/tests/comments-auth.test.js
@@ -3,9 +3,9 @@ const assert = require('node:assert');
 
 const originalEnv = { ...process.env };
 
-process.env.STACK_AUTH_PROJECT_ID = 'proj';
+process.env.STACK_PROJECT_ID = 'proj';
 process.env.STACK_AUTH_CLIENT_ID = 'client';
-process.env.STACK_AUTH_CLIENT_SECRET = 'stacksecret';
+process.env.STACK_SECRET_KEY = 'stacksecret';
 process.env.JWKS_URL = 'https://example.com/jwks.json';
 process.env.DATABASE_URL = 'postgres://localhost/test';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret';

--- a/tests/comments-delete.test.js
+++ b/tests/comments-delete.test.js
@@ -3,9 +3,9 @@ const assert = require('node:assert');
 
 const originalEnv = { ...process.env };
 
-process.env.STACK_AUTH_PROJECT_ID = 'proj';
+process.env.STACK_PROJECT_ID = 'proj';
 process.env.STACK_AUTH_CLIENT_ID = 'client';
-process.env.STACK_AUTH_CLIENT_SECRET = 'stacksecret';
+process.env.STACK_SECRET_KEY = 'stacksecret';
 process.env.JWKS_URL = 'https://example.com/jwks.json';
 process.env.DATABASE_URL = 'postgres://localhost/test';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret';

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -4,12 +4,12 @@ const assert = require('node:assert');
 const originalEnv = { ...process.env };
 
 test('health endpoint returns 500 when config missing', async () => {
-  process.env.STACK_AUTH_PROJECT_ID = 'proj';
+  process.env.STACK_PROJECT_ID = 'proj';
   process.env.JWT_SECRET = 'secret';
   process.env.SESSION_SECRET = 'sess';
   process.env.JWKS_URL = 'https://example.com/jwks.json';
   process.env.DATABASE_URL = 'postgres://localhost/test';
-  process.env.STACK_AUTH_CLIENT_SECRET = 'stacksecret';
+  process.env.STACK_SECRET_KEY = 'stacksecret';
   delete process.env.STACK_AUTH_CLIENT_ID;
   delete require.cache[require.resolve('../lib/auth')];
   delete require.cache[require.resolve('../api/health.js')];

--- a/tests/malformed-json.test.js
+++ b/tests/malformed-json.test.js
@@ -3,9 +3,9 @@ const assert = require('node:assert');
 const { newDb } = require('pg-mem');
 
 const originalEnv = { ...process.env };
-process.env.STACK_AUTH_PROJECT_ID = 'proj';
+process.env.STACK_PROJECT_ID = 'proj';
 process.env.STACK_AUTH_CLIENT_ID = 'client';
-process.env.STACK_AUTH_CLIENT_SECRET = 'stacksecret';
+process.env.STACK_SECRET_KEY = 'stacksecret';
 process.env.JWKS_URL = 'https://example.com/jwks.json';
 process.env.DATABASE_URL = 'postgres://localhost/test';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret';

--- a/tests/posts-admin-forbidden.test.js
+++ b/tests/posts-admin-forbidden.test.js
@@ -2,9 +2,9 @@ const test = require('node:test');
 const assert = require('node:assert');
 
 const originalEnv = { ...process.env };
-process.env.STACK_AUTH_PROJECT_ID = 'proj';
+process.env.STACK_PROJECT_ID = 'proj';
 process.env.STACK_AUTH_CLIENT_ID = 'client';
-process.env.STACK_AUTH_CLIENT_SECRET = 'stacksecret';
+process.env.STACK_SECRET_KEY = 'stacksecret';
 process.env.JWKS_URL = 'https://example.com/jwks.json';
 process.env.DATABASE_URL = 'postgres://localhost/test';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret';

--- a/tests/posts-auth-required.test.js
+++ b/tests/posts-auth-required.test.js
@@ -2,9 +2,9 @@ const test = require('node:test');
 const assert = require('node:assert');
 
 const originalEnv = { ...process.env };
-process.env.STACK_AUTH_PROJECT_ID = 'proj';
+process.env.STACK_PROJECT_ID = 'proj';
 process.env.STACK_AUTH_CLIENT_ID = 'client';
-process.env.STACK_AUTH_CLIENT_SECRET = 'stacksecret';
+process.env.STACK_SECRET_KEY = 'stacksecret';
 process.env.JWKS_URL = 'https://example.com/jwks.json';
 process.env.DATABASE_URL = 'postgres://localhost/test';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret';

--- a/tests/slug-update.test.js
+++ b/tests/slug-update.test.js
@@ -3,9 +3,9 @@ const assert = require('node:assert');
 const { newDb } = require('pg-mem');
 
 const originalEnv = { ...process.env };
-process.env.STACK_AUTH_PROJECT_ID = 'proj';
+process.env.STACK_PROJECT_ID = 'proj';
 process.env.STACK_AUTH_CLIENT_ID = 'client';
-process.env.STACK_AUTH_CLIENT_SECRET = 'stacksecret';
+process.env.STACK_SECRET_KEY = 'stacksecret';
 process.env.JWKS_URL = 'https://example.com/jwks.json';
 process.env.DATABASE_URL = 'postgres://localhost/test';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret';


### PR DESCRIPTION
## Summary
- Make `ensureConfig` accept explicit env keys and allow JWKS_URL or JWT_SECRET fallback
- Refactor auth routes to require only the env vars they use
- Replace legacy env names with STACK_PROJECT_ID and STACK_SECRET_KEY, update docs and tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689943d017d8832882a0a313e669daeb