### PR TITLE
fix: correct lib import paths in admin routes

### DIFF
--- a/api/admin/users/[id].js
+++ b/api/admin/users/[id].js
@@ -1,7 +1,7 @@
-const db = require('../../../lib/db');
-const requireAdmin = require('../../../lib/requireAdmin');
-const { ensureCsrf, validateCsrf } = require('../../../lib/csrf');
-const { ensureConfig } = require('../../../lib/auth');
+const db = require('../../lib/db');
+const requireAdmin = require('../../lib/requireAdmin');
+const { ensureCsrf, validateCsrf } = require('../../lib/csrf');
+const { ensureConfig } = require('../../lib/auth');
 
 module.exports = async (req, res) => {
   const id = req.query.id;

--- a/api/admin/users/index.js
+++ b/api/admin/users/index.js
@@ -1,6 +1,6 @@
-const db = require('../../../lib/db');
-const requireAdmin = require('../../../lib/requireAdmin');
-const { ensureConfig } = require('../../../lib/auth');
+const db = require('../../lib/db');
+const requireAdmin = require('../../lib/requireAdmin');
+const { ensureConfig } = require('../../lib/auth');
 
 module.exports = async (req, res) => {
   try {


### PR DESCRIPTION
## Summary
- fix lib import paths in API admin user routes to use ../../lib
- ensure consistent path usage for shared modules

## Testing
- `npm test`

