### PR TITLE
Expose OAuth flag and add auth debug endpoint

### DIFF
--- a/api/auth/debug.js
+++ b/api/auth/debug.js
@@ -1,0 +1,21 @@
+module.exports = (req, res) => {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({ error: 'method_not_allowed' });
+  }
+  const keys = [
+    'STACK_PROJECT_ID',
+    'STACK_AUTH_CLIENT_ID',
+    'STACK_SECRET_KEY',
+    'DATABASE_URL',
+    'JWKS_URL',
+    'JWT_SECRET',
+    'SESSION_SECRET',
+  ];
+  const info = {};
+  for (const k of keys) {
+    info[k] = !!process.env[k];
+  }
+  info.NEXT_PUBLIC_HAS_OAUTH = process.env.NEXT_PUBLIC_HAS_OAUTH === 'true';
+  return res.status(200).json(info);
+};

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,5 +1,8 @@
 const { createRemoteJWKSet, jwtVerify, SignJWT } = require('jose');
 
+// Expose OAuth availability to the frontend at build time
+process.env.NEXT_PUBLIC_HAS_OAUTH = process.env.STACK_AUTH_CLIENT_ID ? 'true' : 'false';
+
 // Backward-compat default. New code should pass explicit keys.
 const REQUIRED_KEYS = [
   'DATABASE_URL',

--- a/login.html
+++ b/login.html
@@ -5,12 +5,21 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Login - AI News Hub</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <script>window.NEXT_PUBLIC_HAS_OAUTH = process.env.NEXT_PUBLIC_HAS_OAUTH === 'true';</script>
 </head>
 <body class="bg-light dark:bg-dark">
   <main class="max-w-md mx-auto p-6 text-center">
     <h1 class="text-2xl font-bold mb-6">Login</h1>
-    <a href="/api/auth/oauth/google" class="block w-full bg-primary text-white px-4 py-2 rounded mb-4">Login with Google</a>
+    <a id="google-login" href="/api/auth/oauth/google" class="block w-full bg-primary text-white px-4 py-2 rounded mb-4">Login with Google</a>
     <a href="/api/auth/oauth/github" class="block w-full bg-gray-800 text-white px-4 py-2 rounded">Login with GitHub</a>
   </main>
+  <script>
+    if (!window.NEXT_PUBLIC_HAS_OAUTH) {
+      const btn = document.getElementById('google-login');
+      if (btn) {
+        btn.classList.add('hidden');
+      }
+    }
+  </script>
 </body>
 </html>

--- a/tests/oauth-flag.test.js
+++ b/tests/oauth-flag.test.js
@@ -1,0 +1,20 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+const originalEnv = { ...process.env };
+
+test('NEXT_PUBLIC_HAS_OAUTH reflects STACK_AUTH_CLIENT_ID', () => {
+  delete require.cache[require.resolve('../lib/auth')];
+  delete process.env.STACK_AUTH_CLIENT_ID;
+  require('../lib/auth');
+  assert.strictEqual(process.env.NEXT_PUBLIC_HAS_OAUTH, 'false');
+
+  delete require.cache[require.resolve('../lib/auth')];
+  process.env.STACK_AUTH_CLIENT_ID = 'abc';
+  require('../lib/auth');
+  assert.strictEqual(process.env.NEXT_PUBLIC_HAS_OAUTH, 'true');
+});
+
+test.after(() => {
+  process.env = originalEnv;
+});


### PR DESCRIPTION
## Summary
- expose NEXT_PUBLIC_HAS_OAUTH based on STACK_AUTH_CLIENT_ID
- add /api/auth/debug endpoint reporting env status
- hide Google login button when OAuth is unavailable
- add unit test covering OAuth flag

## Testing
- `npm test`

