### PR TITLE
fix: include project ID in Stack Auth OAuth endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Replace `example@domain.com` with the email of the account you want to promote.
    - `JWKS_URL` – `https://api.stack-auth.com/api/v1/projects/<project_id>/.well-known/jwks.json`
    - `STACK_AUTH_PROJECT_ID` – your Neon Auth project ID.
    - `STACK_AUTH_CLIENT_ID` – OAuth client ID from Neon Auth.
+   - `STACK_AUTH_CLIENT_SECRET` – OAuth client secret from Neon Auth.
 3. Add trusted domains in Neon Auth:
    - `http://localhost:3000`
    - Your production URL

--- a/api/auth/callback.js
+++ b/api/auth/callback.js
@@ -32,7 +32,7 @@ module.exports = async (req, res) => {
       res.setHeader('Set-Cookie', [clearState, clearPkce]);
       return res.status(400).json({ error: 'invalid_state' });
     }
-    if (!code) {
+    if (!code || !provider) {
       res.setHeader('Set-Cookie', [clearState, clearPkce]);
       return res.status(400).json({ error: 'invalid_oauth_response' });
     }
@@ -41,24 +41,27 @@ module.exports = async (req, res) => {
     const host = req.headers['x-forwarded-host'] || req.headers.host;
     const baseUrl = `${proto}://${host}`;
 
-    const projectId = process.env.STACK_PROJECT_ID;
-    const serverSecret = process.env.STACK_SECRET_KEY;
+    const clientId = process.env.STACK_AUTH_CLIENT_ID;
+    const clientSecret = process.env.STACK_AUTH_CLIENT_SECRET;
+    const projectId = process.env.STACK_AUTH_PROJECT_ID;
 
     const tokenRes = await fetch(
-  `https://api.stack-auth.com/api/v1/projects/${projectId}/auth/oauth/token`,
-  {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({
-      client_id: projectId,
-      client_secret: serverSecret,
-      grant_type: 'authorization_code',
-      code,
-      redirect_uri: `${baseUrl}/api/auth/callback`,
-      code_verifier: verifier,
-    }),
-  }
-);
+      `https://api.stack-auth.com/api/v1/${encodeURIComponent(
+        projectId
+      )}/auth/oauth/token/${encodeURIComponent(provider)}`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          client_id: clientId,
+          client_secret: clientSecret,
+          grant_type: 'authorization_code',
+          code,
+          redirect_uri: `${baseUrl}/api/auth/callback`,
+          code_verifier: verifier,
+        }),
+      }
+    );
 
     const tokenData = await tokenRes.json();
     console.log('/api/auth/callback: tokenData', tokenData);

--- a/api/auth/oauth/[provider].js
+++ b/api/auth/oauth/[provider].js
@@ -1,6 +1,6 @@
 // /api/auth/oauth/[provider].js
 const crypto = require('crypto');
-const { ensureConfig } = require('../../../lib/auth');
+const { ensureConfig } = require('../../lib/auth');
 
 function b64url(buf) {
   return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
@@ -13,48 +13,57 @@ module.exports = async (req, res) => {
   }
 
   try {
-    ensureConfig(); // throws if env is missing
+    ensureConfig();
 
     const provider = req.query.provider;
     if (!provider) return res.status(400).json({ error: 'missing_provider' });
 
     const proto = req.headers['x-forwarded-proto'] || 'https';
-    const host  = req.headers['x-forwarded-host'] || req.headers.host;
+    const host = req.headers['x-forwarded-host'] || req.headers.host;
     const baseUrl = `${proto}://${host}`;
     const redirectUri = `${baseUrl}/api/auth/callback`;
 
-    // pull from env (publishable is safe for client; still fine here)
-    const projectId  = process.env.STACK_AUTH_PROJECT_ID || process.env.NEXT_PUBLIC_STACK_PROJECT_ID;
-    const clientId   = process.env.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY;
-
-    if (!projectId || !clientId) {
+    const clientId = process.env.STACK_AUTH_CLIENT_ID;
+    const projectId = process.env.STACK_AUTH_PROJECT_ID;
+    if (!clientId || !projectId) {
       return res.status(500).json({ error: 'server_config_error' });
     }
 
-    // PKCE
-    const codeVerifier  = b64url(crypto.randomBytes(32));
-    const codeChallenge = b64url(crypto.createHash('sha256').update(codeVerifier).digest());
-    const state         = b64url(crypto.randomBytes(16));
+    const verifier = b64url(crypto.randomBytes(32));
+    const challenge = b64url(crypto.createHash('sha256').update(verifier).digest());
+    const state = b64url(crypto.randomBytes(16));
 
     res.setHeader('Set-Cookie', [
-      `pkce_verifier=${codeVerifier}; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=600`,
+      `pkce_verifier=${verifier}; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=600`,
       `oauth_state=${state}; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=600`,
     ]);
 
-    // Correct, project-scoped Stack Auth authorize endpoint
-    const authorizeUrl =
-      `https://api.stack-auth.com/api/v1/projects/${projectId}/auth/oauth/authorize` +
-      `?provider=${encodeURIComponent(provider)}` +
-      `&client_id=${encodeURIComponent(clientId)}` +
-      `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-      `&response_type=code&scope=${encodeURIComponent('openid email profile')}` +
-      `&code_challenge_method=S256&code_challenge=${encodeURIComponent(codeChallenge)}` +
-      `&state=${encodeURIComponent(state)}`;
+    const authorizeUrl = new URL(
+      `https://api.stack-auth.com/api/v1/${encodeURIComponent(
+        projectId
+      )}/auth/oauth/authorize/${encodeURIComponent(provider)}`
+    );
+    authorizeUrl.searchParams.set('client_id', clientId);
+    authorizeUrl.searchParams.set('redirect_uri', redirectUri);
+    authorizeUrl.searchParams.set('response_type', 'code');
+    authorizeUrl.searchParams.set('scope', 'openid email profile');
+    authorizeUrl.searchParams.set('code_challenge_method', 'S256');
+    authorizeUrl.searchParams.set('code_challenge', challenge);
+    authorizeUrl.searchParams.set('state', state);
 
-    res.writeHead(302, { Location: authorizeUrl });
+    console.log('/api/auth/oauth', {
+      provider,
+      host,
+      path: req.url,
+      state: `...${state.slice(-6)}`,
+      challenge: `...${challenge.slice(-6)}`,
+    });
+
+    res.writeHead(302, { Location: authorizeUrl.toString() });
     res.end();
   } catch (err) {
     console.error('/api/auth/oauth/[provider] error:', err);
     return res.status(500).json({ error: 'server_error' });
   }
 };
+

--- a/api/lib/auth.js
+++ b/api/lib/auth.js
@@ -1,0 +1,1 @@
+module.exports = require('../../lib/auth');

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -2,8 +2,9 @@ const { createRemoteJWKSet, jwtVerify, SignJWT } = require('jose');
 
 const REQUIRED_KEYS = [
   'DATABASE_URL',
-  'STACK_PROJECT_ID',
+  'STACK_AUTH_PROJECT_ID',
   'STACK_AUTH_CLIENT_ID',
+  'STACK_AUTH_CLIENT_SECRET',
   'JWKS_URL',
   'JWT_SECRET',
   'SESSION_SECRET',

--- a/tests/auth-me.test.js
+++ b/tests/auth-me.test.js
@@ -2,9 +2,9 @@ const test = require('node:test');
 const assert = require('node:assert');
 
 const originalEnv = { ...process.env };
-process.env.STACK_PROJECT_ID = 'proj';
+process.env.STACK_AUTH_PROJECT_ID = 'proj';
 process.env.STACK_AUTH_CLIENT_ID = 'client';
-process.env.STACK_SECRET_KEY = 'stacksecret';
+process.env.STACK_AUTH_CLIENT_SECRET = 'stacksecret';
 process.env.JWKS_URL = 'https://example.com/jwks.json';
 process.env.DATABASE_URL = 'postgres://localhost/test';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret';

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -3,9 +3,9 @@ const assert = require('node:assert');
 
 const originalEnv = { ...process.env };
 
-process.env.STACK_PROJECT_ID = 'proj';
+process.env.STACK_AUTH_PROJECT_ID = 'proj';
 process.env.STACK_AUTH_CLIENT_ID = 'client';
-process.env.STACK_SECRET_KEY = 'stacksecret';
+process.env.STACK_AUTH_CLIENT_SECRET = 'stacksecret';
 process.env.JWKS_URL = 'https://example.com/jwks.json';
 process.env.DATABASE_URL = 'postgres://localhost/test';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret';

--- a/tests/comments-auth.test.js
+++ b/tests/comments-auth.test.js
@@ -3,9 +3,9 @@ const assert = require('node:assert');
 
 const originalEnv = { ...process.env };
 
-process.env.STACK_PROJECT_ID = 'proj';
+process.env.STACK_AUTH_PROJECT_ID = 'proj';
 process.env.STACK_AUTH_CLIENT_ID = 'client';
-process.env.STACK_SECRET_KEY = 'stacksecret';
+process.env.STACK_AUTH_CLIENT_SECRET = 'stacksecret';
 process.env.JWKS_URL = 'https://example.com/jwks.json';
 process.env.DATABASE_URL = 'postgres://localhost/test';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret';

--- a/tests/comments-delete.test.js
+++ b/tests/comments-delete.test.js
@@ -3,9 +3,9 @@ const assert = require('node:assert');
 
 const originalEnv = { ...process.env };
 
-process.env.STACK_PROJECT_ID = 'proj';
+process.env.STACK_AUTH_PROJECT_ID = 'proj';
 process.env.STACK_AUTH_CLIENT_ID = 'client';
-process.env.STACK_SECRET_KEY = 'stacksecret';
+process.env.STACK_AUTH_CLIENT_SECRET = 'stacksecret';
 process.env.JWKS_URL = 'https://example.com/jwks.json';
 process.env.DATABASE_URL = 'postgres://localhost/test';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret';

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -4,11 +4,12 @@ const assert = require('node:assert');
 const originalEnv = { ...process.env };
 
 test('health endpoint returns 500 when config missing', async () => {
-  process.env.STACK_PROJECT_ID = 'proj';
+  process.env.STACK_AUTH_PROJECT_ID = 'proj';
   process.env.JWT_SECRET = 'secret';
   process.env.SESSION_SECRET = 'sess';
   process.env.JWKS_URL = 'https://example.com/jwks.json';
   process.env.DATABASE_URL = 'postgres://localhost/test';
+  process.env.STACK_AUTH_CLIENT_SECRET = 'stacksecret';
   delete process.env.STACK_AUTH_CLIENT_ID;
   delete require.cache[require.resolve('../lib/auth')];
   delete require.cache[require.resolve('../api/health.js')];

--- a/tests/malformed-json.test.js
+++ b/tests/malformed-json.test.js
@@ -3,9 +3,9 @@ const assert = require('node:assert');
 const { newDb } = require('pg-mem');
 
 const originalEnv = { ...process.env };
-process.env.STACK_PROJECT_ID = 'proj';
+process.env.STACK_AUTH_PROJECT_ID = 'proj';
 process.env.STACK_AUTH_CLIENT_ID = 'client';
-process.env.STACK_SECRET_KEY = 'stacksecret';
+process.env.STACK_AUTH_CLIENT_SECRET = 'stacksecret';
 process.env.JWKS_URL = 'https://example.com/jwks.json';
 process.env.DATABASE_URL = 'postgres://localhost/test';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret';

--- a/tests/posts-admin-forbidden.test.js
+++ b/tests/posts-admin-forbidden.test.js
@@ -2,9 +2,9 @@ const test = require('node:test');
 const assert = require('node:assert');
 
 const originalEnv = { ...process.env };
-process.env.STACK_PROJECT_ID = 'proj';
+process.env.STACK_AUTH_PROJECT_ID = 'proj';
 process.env.STACK_AUTH_CLIENT_ID = 'client';
-process.env.STACK_SECRET_KEY = 'stacksecret';
+process.env.STACK_AUTH_CLIENT_SECRET = 'stacksecret';
 process.env.JWKS_URL = 'https://example.com/jwks.json';
 process.env.DATABASE_URL = 'postgres://localhost/test';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret';

--- a/tests/posts-auth-required.test.js
+++ b/tests/posts-auth-required.test.js
@@ -2,9 +2,9 @@ const test = require('node:test');
 const assert = require('node:assert');
 
 const originalEnv = { ...process.env };
-process.env.STACK_PROJECT_ID = 'proj';
+process.env.STACK_AUTH_PROJECT_ID = 'proj';
 process.env.STACK_AUTH_CLIENT_ID = 'client';
-process.env.STACK_SECRET_KEY = 'stacksecret';
+process.env.STACK_AUTH_CLIENT_SECRET = 'stacksecret';
 process.env.JWKS_URL = 'https://example.com/jwks.json';
 process.env.DATABASE_URL = 'postgres://localhost/test';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret';

--- a/tests/slug-update.test.js
+++ b/tests/slug-update.test.js
@@ -3,9 +3,9 @@ const assert = require('node:assert');
 const { newDb } = require('pg-mem');
 
 const originalEnv = { ...process.env };
-process.env.STACK_PROJECT_ID = 'proj';
+process.env.STACK_AUTH_PROJECT_ID = 'proj';
 process.env.STACK_AUTH_CLIENT_ID = 'client';
-process.env.STACK_SECRET_KEY = 'stacksecret';
+process.env.STACK_AUTH_CLIENT_SECRET = 'stacksecret';
 process.env.JWKS_URL = 'https://example.com/jwks.json';
 process.env.DATABASE_URL = 'postgres://localhost/test';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret';


### PR DESCRIPTION
## Summary
- include `STACK_AUTH_PROJECT_ID` in Stack Auth authorization and token URLs
- build authorization URL with `URL` API and PKCE parameters

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68993b626e708328b6b1acd167dcd3f3