### PR TITLE
fix: correct stack auth oauth paths and envs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 DATABASE_URL=postgres://user:password@host:5432/db?sslmode=require
 SESSION_SECRET=changeme
 JWT_SECRET=changeme
-STACK_PROJECT_ID=your-stack-project-id
-STACK_SECRET_KEY=your-stack-secret-key
+STACK_AUTH_PROJECT_ID=your-stack-project-id
+STACK_AUTH_CLIENT_SECRET=your-stack-auth-client-secret
 STACK_AUTH_CLIENT_ID=your-stack-auth-client-id
 JWKS_URL=https://api.stack-auth.com/api/v1/projects/your-stack-project-id/.well-known/jwks.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 - Dateien: `api/**`
 - DB: Postgres (Neon), Tabelle `public.posts`
 - Spalten (wichtig): id, slug (unique), title, excerpt, content, category, tags text[], author, image_url, published_at timestamptz default now()
-- ENV: `DATABASE_URL` (SSL), `STACK_PROJECT_ID`, `STACK_AUTH_CLIENT_ID`, `STACK_SECRET_KEY`
+- ENV: `DATABASE_URL` (SSL), `STACK_AUTH_PROJECT_ID`, `STACK_AUTH_CLIENT_ID`, `STACK_AUTH_CLIENT_SECRET`
 
 ## Regeln
 - Keine breaking Schema-Änderungen ohne Migration

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Replace `example@domain.com` with the email of the account you want to promote.
    - `DATABASE_URL` – Postgres connection string (Neon requires SSL).
    - `SESSION_SECRET` – Secret for signing the `session` cookie.
    - `JWT_SECRET` – Secret used to sign/verify JWTs locally.
-   - `STACK_PROJECT_ID`, `STACK_SECRET_KEY`, `STACK_AUTH_CLIENT_ID` – credentials from Stack Auth.
+    - `STACK_AUTH_PROJECT_ID`, `STACK_AUTH_CLIENT_SECRET`, `STACK_AUTH_CLIENT_ID` – credentials from Stack Auth.
    - `JWKS_URL` – JWKS endpoint from Stack Auth or another provider.
 3. Start the development server (requires the [Vercel CLI](https://vercel.com/docs/cli)):
    ```bash
@@ -49,8 +49,8 @@ Replace `example@domain.com` with the email of the account you want to promote.
    - `https://your-production-domain/api/auth/callback`
    These URIs must also be allowed in the Google Cloud console.
 3. Copy the credentials from the Stack Auth dashboard and set:
-   - `STACK_PROJECT_ID`
-   - `STACK_SECRET_KEY`
+    - `STACK_AUTH_PROJECT_ID`
+    - `STACK_AUTH_CLIENT_SECRET`
    - `STACK_AUTH_CLIENT_ID`
    - `JWKS_URL` – `https://api.stack-auth.com/api/v1/projects/<project_id>/.well-known/jwks.json`
 
@@ -115,8 +115,8 @@ This endpoint may be rate limited to prevent abuse.
 
 1. Push the repository to your Git host and [import it into Vercel](https://vercel.com/new).
 2. In **Project Settings → Environment Variables**, set the variables from `.env.example`
-   (`DATABASE_URL`, `SESSION_SECRET`, `JWT_SECRET`, `STACK_PROJECT_ID`, `STACK_SECRET_KEY`,
-   `STACK_AUTH_CLIENT_ID`, and `JWKS_URL` if used).
+    (`DATABASE_URL`, `SESSION_SECRET`, `JWT_SECRET`, `STACK_AUTH_PROJECT_ID`, `STACK_AUTH_CLIENT_SECRET`,
+    `STACK_AUTH_CLIENT_ID`, and `JWKS_URL` if used).
 3. Deploy or trigger a redeploy after saving variables so the build receives the new values.
    Vercel builds the static files and exposes the `api/` directory as serverless functions.
 4. After deployment, ensure [docs/db-migration.sql](docs/db-migration.sql) has been run on

--- a/api/auth/callback.js
+++ b/api/auth/callback.js
@@ -19,34 +19,36 @@ module.exports = async (req, res) => {
   );
   const stateCookie = cookies.oauth_state;
   const verifier = cookies.pkce_verifier || '';
-  const providerCookie = cookies.oauth_provider;
   const clearState =
     'oauth_state=; Max-Age=0; HttpOnly; Secure; SameSite=Strict; Path=/';
   const clearPkce =
     'pkce_verifier=; Max-Age=0; HttpOnly; Secure; SameSite=Strict; Path=/';
-  const clearProvider =
-    'oauth_provider=; Max-Age=0; HttpOnly; Secure; SameSite=Strict; Path=/';
 
   try {
     ensureConfig([
       'STACK_AUTH_PROJECT_ID',
       'STACK_AUTH_CLIENT_ID',
       'STACK_AUTH_CLIENT_SECRET',
+      'SESSION_SECRET',
       'JWKS_URL',
       'JWT_SECRET',
     ]);
-    const { state, code, provider: providerQuery } = req.query || {};
-    const provider = providerQuery || providerCookie;
+    const { state, code, provider } = req.query || {};
+    if (!provider) {
+      console.error('/api/auth/callback: missing_provider');
+      res.setHeader('Set-Cookie', [clearState, clearPkce]);
+      return res.status(400).json({ error: 'missing_provider' });
+    }
     const stateMatch = Boolean(state && stateCookie && stateCookie === state);
     console.log('/api/auth/callback', { provider, stateMatch });
     if (!stateMatch) {
       console.error('/api/auth/callback: invalid_state');
-      res.setHeader('Set-Cookie', [clearState, clearPkce, clearProvider]);
+      res.setHeader('Set-Cookie', [clearState, clearPkce]);
       return res.status(400).json({ error: 'invalid_state' });
     }
-    if (!code || !provider) {
+    if (!code) {
       console.error('/api/auth/callback: invalid_oauth_response');
-      res.setHeader('Set-Cookie', [clearState, clearPkce, clearProvider]);
+      res.setHeader('Set-Cookie', [clearState, clearPkce]);
       return res.status(400).json({ error: 'invalid_oauth_response' });
     }
 
@@ -93,13 +95,18 @@ module.exports = async (req, res) => {
         tokenRes.status,
         errText.slice(0, 100)
       );
-      res.setHeader('Set-Cookie', [clearState, clearPkce, clearProvider]);
+      res.setHeader('Set-Cookie', [clearState, clearPkce]);
       return res.status(400).json({ error: 'invalid_oauth_response' });
     }
 
     const tokenData = await tokenRes.json();
     const accessToken = tokenData.token;
     const idToken = tokenData.id_token;
+    if (!accessToken && !idToken) {
+      console.error('/api/auth/callback: invalid_oauth_response');
+      res.setHeader('Set-Cookie', [clearState, clearPkce]);
+      return res.status(400).json({ error: 'invalid_oauth_response' });
+    }
     const verifyTarget = idToken || accessToken;
 
     let payload;
@@ -110,7 +117,7 @@ module.exports = async (req, res) => {
     }
     if (!payload || !payload.sub) {
       console.error('/api/auth/callback: invalid_oauth_response');
-      res.setHeader('Set-Cookie', [clearState, clearPkce, clearProvider]);
+      res.setHeader('Set-Cookie', [clearState, clearPkce]);
       return res.status(400).json({ error: 'invalid_oauth_response' });
     }
 
@@ -128,7 +135,7 @@ module.exports = async (req, res) => {
     }
     if (!name || !email) {
       console.error('/api/auth/callback: invalid_oauth_response');
-      res.setHeader('Set-Cookie', [clearState, clearPkce, clearProvider]);
+      res.setHeader('Set-Cookie', [clearState, clearPkce]);
       return res.status(400).json({ error: 'invalid_oauth_response' });
     }
 
@@ -150,13 +157,13 @@ module.exports = async (req, res) => {
     const signed = signSessionToken(jwt);
     const sessionCookie = `session=${signed}; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=3600`;
 
-    res.setHeader('Set-Cookie', [sessionCookie, clearState, clearPkce, clearProvider]);
+    res.setHeader('Set-Cookie', [sessionCookie, clearState, clearPkce]);
     console.log('/api/auth/callback: set session cookie for user', user.id);
     res.writeHead(302, { Location: '/' });
     res.end();
   } catch (err) {
     console.error('/api/auth/callback error:', err.message);
-    res.setHeader('Set-Cookie', [clearState, clearPkce, clearProvider]);
+    res.setHeader('Set-Cookie', [clearState, clearPkce]);
     if (err.code === 'CONFIG_ERROR') {
       return res.status(500).json({ error: 'missing_config' });
     }

--- a/api/auth/callback.js
+++ b/api/auth/callback.js
@@ -40,7 +40,7 @@ module.exports = async (req, res) => {
       return res.status(400).json({ error: 'missing_provider' });
     }
     const stateMatch = Boolean(state && stateCookie && stateCookie === state);
-    console.log('/api/auth/callback', { provider, stateMatch });
+    console.log('/api/auth/callback', { provider, stateMatch, hasCode: Boolean(code) });
     if (!stateMatch) {
       console.error('/api/auth/callback: invalid_state');
       res.setHeader('Set-Cookie', [clearState, clearPkce]);
@@ -96,7 +96,7 @@ module.exports = async (req, res) => {
         errText.slice(0, 100)
       );
       res.setHeader('Set-Cookie', [clearState, clearPkce]);
-      return res.status(400).json({ error: 'invalid_oauth_response' });
+      return res.status(502).json({ error: 'token_exchange_failed' });
     }
 
     const tokenData = await tokenRes.json();

--- a/api/auth/debug.js
+++ b/api/auth/debug.js
@@ -4,9 +4,9 @@ module.exports = (req, res) => {
     return res.status(405).json({ error: 'method_not_allowed' });
   }
   const keys = [
-    'STACK_PROJECT_ID',
+    'STACK_AUTH_PROJECT_ID',
     'STACK_AUTH_CLIENT_ID',
-    'STACK_SECRET_KEY',
+    'STACK_AUTH_CLIENT_SECRET',
     'DATABASE_URL',
     'JWKS_URL',
     'JWT_SECRET',

--- a/api/auth/oauth/[provider].js
+++ b/api/auth/oauth/[provider].js
@@ -13,7 +13,7 @@ module.exports = async (req, res) => {
   }
 
   try {
-    ensureConfig(['STACK_AUTH_CLIENT_ID', 'STACK_PROJECT_ID']);
+    ensureConfig(['STACK_AUTH_CLIENT_ID', 'STACK_AUTH_PROJECT_ID']);
 
     const provider = req.query.provider;
     if (!provider) return res.status(400).json({ error: 'missing_provider' });
@@ -21,10 +21,12 @@ module.exports = async (req, res) => {
     const proto = req.headers['x-forwarded-proto'] || 'https';
     const host = req.headers['x-forwarded-host'] || req.headers.host;
     const baseUrl = `${proto}://${host}`;
-    const redirectUri = `${baseUrl}/api/auth/callback`;
+    const redirectUri = `${baseUrl}/api/auth/callback?provider=${encodeURIComponent(
+      provider
+    )}`;
 
     const clientId = process.env.STACK_AUTH_CLIENT_ID;
-    const projectId = process.env.STACK_PROJECT_ID;
+    const projectId = process.env.STACK_AUTH_PROJECT_ID;
 
     const verifier = b64url(crypto.randomBytes(32));
     const challenge = b64url(crypto.createHash('sha256').update(verifier).digest());
@@ -36,32 +38,27 @@ module.exports = async (req, res) => {
       `oauth_provider=${encodeURIComponent(provider)}; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=600`,
     ]);
 
-    const authorizeUrl =
-      `https://api.stack-auth.com/api/v1/projects/${encodeURIComponent(
-        projectId
-      )}/oauth/authorize/${encodeURIComponent(provider)}` +
-      `?client_id=${encodeURIComponent(clientId)}` +
-      `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-      `&response_type=code` +
-      `&scope=${encodeURIComponent('openid email profile')}` +
-      `&code_challenge_method=S256` +
-      `&code_challenge=${encodeURIComponent(challenge)}` +
-      `&state=${encodeURIComponent(state)}`;
+    const url = new URL('https://api.stack-auth.com');
+    url.pathname = `/api/v1/projects/${encodeURIComponent(
+      projectId
+    )}/auth/oauth/authorize/${encodeURIComponent(provider)}`;
+    url.searchParams.set('client_id', clientId);
+    url.searchParams.set('redirect_uri', redirectUri);
+    url.searchParams.set('response_type', 'code');
+    url.searchParams.set('scope', 'openid email profile');
+    url.searchParams.set('code_challenge_method', 'S256');
+    url.searchParams.set('code_challenge', challenge);
+    url.searchParams.set('state', state);
 
-    const maskedAuthorizeUrl = authorizeUrl
-      .replace(
-        encodeURIComponent(challenge),
-        `${encodeURIComponent(challenge.slice(0, 6))}...`
-      )
-      .replace(
-        encodeURIComponent(state),
-        `${encodeURIComponent(state.slice(0, 6))}...`
-      );
+    const authorizeUrl = url.toString();
+    const maskedUrl = new URL(authorizeUrl);
+    maskedUrl.searchParams.set('code_challenge', `${challenge.slice(0, 6)}...`);
+    maskedUrl.searchParams.set('state', `${state.slice(0, 6)}...`);
 
     console.log('/api/auth/oauth', {
       provider,
       host,
-      authorizeUrl: maskedAuthorizeUrl,
+      authorizeUrl: maskedUrl.toString(),
     });
 
     res.writeHead(302, { Location: authorizeUrl });

--- a/api/auth/oauth/[provider].js
+++ b/api/auth/oauth/[provider].js
@@ -35,7 +35,6 @@ module.exports = async (req, res) => {
     res.setHeader('Set-Cookie', [
       `pkce_verifier=${verifier}; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=600`,
       `oauth_state=${state}; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=600`,
-      `oauth_provider=${encodeURIComponent(provider)}; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=600`,
     ]);
 
     const url = new URL('https://api.stack-auth.com');

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -6,9 +6,9 @@ process.env.NEXT_PUBLIC_HAS_OAUTH = process.env.STACK_AUTH_CLIENT_ID ? 'true' : 
 // Backward-compat default. New code should pass explicit keys.
 const REQUIRED_KEYS = [
   'DATABASE_URL',
-  'STACK_PROJECT_ID',
+  'STACK_AUTH_PROJECT_ID',
   'STACK_AUTH_CLIENT_ID',
-  'STACK_SECRET_KEY',
+  'STACK_AUTH_CLIENT_SECRET',
   'SESSION_SECRET',
 ];
 

--- a/tests/auth-me.test.js
+++ b/tests/auth-me.test.js
@@ -2,9 +2,9 @@ const test = require('node:test');
 const assert = require('node:assert');
 
 const originalEnv = { ...process.env };
-process.env.STACK_PROJECT_ID = 'proj';
+process.env.STACK_AUTH_PROJECT_ID = 'proj';
 process.env.STACK_AUTH_CLIENT_ID = 'client';
-process.env.STACK_SECRET_KEY = 'stacksecret';
+process.env.STACK_AUTH_CLIENT_SECRET = 'stacksecret';
 process.env.JWKS_URL = 'https://example.com/jwks.json';
 process.env.DATABASE_URL = 'postgres://localhost/test';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret';

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -3,9 +3,9 @@ const assert = require('node:assert');
 
 const originalEnv = { ...process.env };
 
-process.env.STACK_PROJECT_ID = 'proj';
+process.env.STACK_AUTH_PROJECT_ID = 'proj';
 process.env.STACK_AUTH_CLIENT_ID = 'client';
-process.env.STACK_SECRET_KEY = 'stacksecret';
+process.env.STACK_AUTH_CLIENT_SECRET = 'stacksecret';
 process.env.JWKS_URL = 'https://example.com/jwks.json';
 process.env.DATABASE_URL = 'postgres://localhost/test';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret';

--- a/tests/comments-auth.test.js
+++ b/tests/comments-auth.test.js
@@ -3,9 +3,9 @@ const assert = require('node:assert');
 
 const originalEnv = { ...process.env };
 
-process.env.STACK_PROJECT_ID = 'proj';
+process.env.STACK_AUTH_PROJECT_ID = 'proj';
 process.env.STACK_AUTH_CLIENT_ID = 'client';
-process.env.STACK_SECRET_KEY = 'stacksecret';
+process.env.STACK_AUTH_CLIENT_SECRET = 'stacksecret';
 process.env.JWKS_URL = 'https://example.com/jwks.json';
 process.env.DATABASE_URL = 'postgres://localhost/test';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret';

--- a/tests/comments-delete.test.js
+++ b/tests/comments-delete.test.js
@@ -3,9 +3,9 @@ const assert = require('node:assert');
 
 const originalEnv = { ...process.env };
 
-process.env.STACK_PROJECT_ID = 'proj';
+process.env.STACK_AUTH_PROJECT_ID = 'proj';
 process.env.STACK_AUTH_CLIENT_ID = 'client';
-process.env.STACK_SECRET_KEY = 'stacksecret';
+process.env.STACK_AUTH_CLIENT_SECRET = 'stacksecret';
 process.env.JWKS_URL = 'https://example.com/jwks.json';
 process.env.DATABASE_URL = 'postgres://localhost/test';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret';

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -4,12 +4,12 @@ const assert = require('node:assert');
 const originalEnv = { ...process.env };
 
 test('health endpoint returns 500 when config missing', async () => {
-  process.env.STACK_PROJECT_ID = 'proj';
+  process.env.STACK_AUTH_PROJECT_ID = 'proj';
   process.env.JWT_SECRET = 'secret';
   process.env.SESSION_SECRET = 'sess';
   process.env.JWKS_URL = 'https://example.com/jwks.json';
   process.env.DATABASE_URL = 'postgres://localhost/test';
-  process.env.STACK_SECRET_KEY = 'stacksecret';
+  process.env.STACK_AUTH_CLIENT_SECRET = 'stacksecret';
   delete process.env.STACK_AUTH_CLIENT_ID;
   delete require.cache[require.resolve('../lib/auth')];
   delete require.cache[require.resolve('../api/health.js')];

--- a/tests/malformed-json.test.js
+++ b/tests/malformed-json.test.js
@@ -3,9 +3,9 @@ const assert = require('node:assert');
 const { newDb } = require('pg-mem');
 
 const originalEnv = { ...process.env };
-process.env.STACK_PROJECT_ID = 'proj';
+process.env.STACK_AUTH_PROJECT_ID = 'proj';
 process.env.STACK_AUTH_CLIENT_ID = 'client';
-process.env.STACK_SECRET_KEY = 'stacksecret';
+process.env.STACK_AUTH_CLIENT_SECRET = 'stacksecret';
 process.env.JWKS_URL = 'https://example.com/jwks.json';
 process.env.DATABASE_URL = 'postgres://localhost/test';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret';

--- a/tests/oauth-authorize-path.test.js
+++ b/tests/oauth-authorize-path.test.js
@@ -1,0 +1,25 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+const originalEnv = { ...process.env };
+
+test('authorize URL uses project-scoped auth path', async () => {
+  process.env.STACK_AUTH_PROJECT_ID = 'proj';
+  process.env.STACK_AUTH_CLIENT_ID = 'client';
+  const handler = require('../api/auth/oauth/[provider].js');
+  const req = { method: 'GET', query: { provider: 'google' }, headers: { host: 'example.com' } };
+  let status; let headers = {};
+  const res = {
+    setHeader() {},
+    writeHead(code, h) { status = code; headers = h; return this; },
+    end() {},
+  };
+  await handler(req, res);
+  assert.strictEqual(status, 302);
+  const url = new URL(headers.Location);
+  assert.strictEqual(url.pathname, '/api/v1/projects/proj/auth/oauth/authorize/google');
+});
+
+test.after(() => {
+  process.env = originalEnv;
+});

--- a/tests/posts-admin-forbidden.test.js
+++ b/tests/posts-admin-forbidden.test.js
@@ -2,9 +2,9 @@ const test = require('node:test');
 const assert = require('node:assert');
 
 const originalEnv = { ...process.env };
-process.env.STACK_PROJECT_ID = 'proj';
+process.env.STACK_AUTH_PROJECT_ID = 'proj';
 process.env.STACK_AUTH_CLIENT_ID = 'client';
-process.env.STACK_SECRET_KEY = 'stacksecret';
+process.env.STACK_AUTH_CLIENT_SECRET = 'stacksecret';
 process.env.JWKS_URL = 'https://example.com/jwks.json';
 process.env.DATABASE_URL = 'postgres://localhost/test';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret';

--- a/tests/posts-auth-required.test.js
+++ b/tests/posts-auth-required.test.js
@@ -2,9 +2,9 @@ const test = require('node:test');
 const assert = require('node:assert');
 
 const originalEnv = { ...process.env };
-process.env.STACK_PROJECT_ID = 'proj';
+process.env.STACK_AUTH_PROJECT_ID = 'proj';
 process.env.STACK_AUTH_CLIENT_ID = 'client';
-process.env.STACK_SECRET_KEY = 'stacksecret';
+process.env.STACK_AUTH_CLIENT_SECRET = 'stacksecret';
 process.env.JWKS_URL = 'https://example.com/jwks.json';
 process.env.DATABASE_URL = 'postgres://localhost/test';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret';

--- a/tests/slug-update.test.js
+++ b/tests/slug-update.test.js
@@ -3,9 +3,9 @@ const assert = require('node:assert');
 const { newDb } = require('pg-mem');
 
 const originalEnv = { ...process.env };
-process.env.STACK_PROJECT_ID = 'proj';
+process.env.STACK_AUTH_PROJECT_ID = 'proj';
 process.env.STACK_AUTH_CLIENT_ID = 'client';
-process.env.STACK_SECRET_KEY = 'stacksecret';
+process.env.STACK_AUTH_CLIENT_SECRET = 'stacksecret';
 process.env.JWKS_URL = 'https://example.com/jwks.json';
 process.env.DATABASE_URL = 'postgres://localhost/test';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret';


### PR DESCRIPTION
## Summary
- build Stack Auth authorize URLs with project-scoped `/auth/oauth/authorize/{provider}` and mask state/challenge logs
- exchange codes at `/auth/oauth/token/{provider}` using form-encoded data
- standardize Stack Auth env vars to `STACK_AUTH_PROJECT_ID`, `STACK_AUTH_CLIENT_ID`, and `STACK_AUTH_CLIENT_SECRET`
- add test ensuring authorize path contains single `oauth`

## Testing
- `npm test`

