### PR TITLE
feat: add email auth pages and legal resources

### DIFF
--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -1,8 +1,50 @@
-module.exports = (req, res) => {
-  if (req.method !== 'GET') {
-    res.setHeader('Allow', 'GET');
+const db = require('../../lib/db');
+const bcrypt = require('bcryptjs');
+const { signJWT } = require('../../lib/auth');
+const { signSessionToken } = require('../../lib/cookies');
+
+module.exports = async (req, res) => {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
     return res.status(405).json({ error: 'method_not_allowed' });
   }
-  res.writeHead(302, { Location: '/api/auth/oauth/google' });
-  res.end();
+
+  const { email, password, remember } = req.body || {};
+  if (!email || !password) {
+    return res.status(400).json({ error: 'missing_fields' });
+  }
+
+  try {
+    // TODO: replace with real DB lookup
+    const { rows } = await db.query(
+      'SELECT id, name, email, password_hash, role FROM users WHERE email=$1',
+      [email]
+    );
+    const user = rows[0];
+    if (!user) {
+      return res.status(401).json({ error: 'invalid_credentials' });
+    }
+
+    // TODO: replace with proper password verification
+    const valid = await bcrypt.compare(password, user.password_hash || '');
+    if (!valid) {
+      return res.status(401).json({ error: 'invalid_credentials' });
+    }
+
+    const jwt = await signJWT(
+      { sub: String(user.id), email: user.email, name: user.name, role: user.role },
+      remember ? '7d' : '1d'
+    );
+    const signed = signSessionToken(jwt);
+    const maxAge = remember ? 60 * 60 * 24 * 7 : 60 * 60 * 24;
+    res.setHeader(
+      'Set-Cookie',
+      `session=${signed}; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=${maxAge}`
+    );
+    return res.status(200).json({ ok: true });
+  } catch (err) {
+    console.error('/api/auth/login error:', err);
+    return res.status(500).json({ error: 'server_error' });
+  }
 };
+

--- a/api/auth/oauth/[provider].js
+++ b/api/auth/oauth/[provider].js
@@ -38,16 +38,15 @@ module.exports = async (req, res) => {
       `oauth_state=${state}; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=600`
     ]);
 
-    const clientId     = process.env.STACK_AUTH_PROJECT_ID; // project UUID
-    const clientSecret = process.env.STACK_AUTH_CLIENT_ID;  // publishable pck_ key
+    const projectId = process.env.STACK_AUTH_PROJECT_ID; // project UUID
+    const clientId  = process.env.STACK_AUTH_CLIENT_ID;  // publishable pck_ key
 
-    // Correct Stack Auth authorize endpoint (provider in the path)
-    const url = new URL(`https://api.stack-auth.com/api/v1/auth/oauth/authorize/${encodeURIComponent(provider)}`);
+    // Correct Stack Auth authorize endpoint (provider in the path, project scoped)
+    const url = new URL(`https://api.stack-auth.com/api/v1/projects/${encodeURIComponent(projectId)}/auth/oauth/authorize/${encodeURIComponent(provider)}`);
     url.searchParams.set('client_id', clientId);
-    url.searchParams.set('client_secret', clientSecret);
     url.searchParams.set('redirect_uri', redirectUri);
     url.searchParams.set('response_type', 'code');
-    url.searchParams.set('https://www.googleapis.com/auth/userinfo.profile+openid+https://www.googleapis.com/auth/userinfo.email'); // keep EXACTLY these; they must match your provider config
+    url.searchParams.set('scope', 'https://www.googleapis.com/auth/userinfo.profile openid https://www.googleapis.com/auth/userinfo.email'); // keep EXACTLY these; they must match your provider config
     url.searchParams.set('code_challenge_method', 'S256');
     url.searchParams.set('code_challenge', codeChallenge);
     url.searchParams.set('state', state);

--- a/index.html
+++ b/index.html
@@ -114,8 +114,8 @@
           </div>
 
           <div id="auth-area" class="flex items-center gap-2">
-            <a id="login-link" href="/api/auth/oauth/google" class="px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Login</a>
-            <a id="signup-link" href="/signup.html" class="px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Sign Up</a>
+            <a id="login-link" href="/login.html" class="px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Sign in</a>
+            <a id="signup-link" href="/signup.html" class="px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Sign up</a>
             <div id="user-info" class="hidden items-center gap-2">
               <span id="user-name" class="font-medium"></span>
               <a id="admin-link" href="/admin.html" class="hidden px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Admin</a>
@@ -258,19 +258,19 @@
         <div>
           <h3 class="text-lg font-semibold mb-3">Resources</h3>
           <ul class="space-y-2 text-slate-400">
-            <li><a href="#" class="hover:text-white">AI Glossary</a></li>
-            <li><a href="#" class="hover:text-white">Research Papers</a></li>
-            <li><a href="#" class="hover:text-white">Tutorials</a></li>
-            <li><a href="#" class="hover:text-white">Events Calendar</a></li>
+            <li><a href="/resources/glossary.html" class="hover:text-white">AI Glossary</a></li>
+            <li><a href="/resources/research.html" class="hover:text-white">Research Papers</a></li>
+            <li><a href="/resources/tutorials.html" class="hover:text-white">Tutorials</a></li>
+            <li><a href="/resources/events.html" class="hover:text-white">Events Calendar</a></li>
           </ul>
         </div>
 
         <div>
           <h3 class="text-lg font-semibold mb-3">Legal</h3>
           <ul class="space-y-2 text-slate-400">
-            <li><a href="#" class="hover:text-white">Privacy Policy</a></li>
-            <li><a href="#" class="hover:text-white">Terms of Service</a></li>
-            <li><a href="#" class="hover:text-white">Cookie Policy</a></li>
+            <li><a href="/legal/privacy.html" class="hover:text-white">Privacy Policy</a></li>
+            <li><a href="/legal/terms.html" class="hover:text-white">Terms of Service</a></li>
+            <li><a href="/legal/cookie-policy.html" class="hover:text-white">Cookie Policy</a></li>
           </ul>
         </div>
       </div>

--- a/legal/cookie-policy.html
+++ b/legal/cookie-policy.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Cookie Policy - AI News Hub</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          colors: { primary: '#0ea5e9', secondary: '#06b6d4', dark: '#0f172a', light: '#f8fafc', accent: '#818cf8' },
+          fontFamily: { inter: ['Inter', 'sans-serif'] }
+        }
+      }
+    };
+    if (localStorage.getItem('theme') === 'dark') document.documentElement.classList.add('dark');
+  </script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body class="bg-light dark:bg-dark text-slate-900 dark:text-slate-100 font-inter">
+  <header class="bg-white dark:bg-slate-900 border-b border-slate-200 dark:border-slate-800">
+    <div class="max-w-7xl mx-auto flex justify-between items-center p-4">
+      <a href="/" class="text-xl font-bold">AI News Hub</a>
+      <nav class="flex gap-4 text-sm">
+        <a href="/login.html" class="hover:underline">Sign in</a>
+        <a href="/signup.html" class="hover:underline">Sign up</a>
+      </nav>
+    </div>
+  </header>
+  <main class="max-w-3xl mx-auto p-6">
+    <h1 class="text-3xl font-bold mb-4">Cookie Policy</h1>
+    <section class="space-y-4 text-slate-700 dark:text-slate-300">
+      <p>This is the cookie policy. Replace with real content.</p>
+    </section>
+  </main>
+  <footer class="bg-white dark:bg-slate-900 border-t border-slate-200 dark:border-slate-800 mt-12">
+    <div class="max-w-7xl mx-auto p-8 grid grid-cols-1 md:grid-cols-3 gap-8 text-sm text-slate-500">
+      <div>
+        <h3 class="text-slate-800 dark:text-slate-200 font-semibold mb-2">Resources</h3>
+        <ul class="space-y-1">
+          <li><a href="/resources/glossary.html" class="hover:underline">AI Glossary</a></li>
+          <li><a href="/resources/research.html" class="hover:underline">Research Papers</a></li>
+          <li><a href="/resources/tutorials.html" class="hover:underline">Tutorials</a></li>
+          <li><a href="/resources/events.html" class="hover:underline">Events Calendar</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3 class="text-slate-800 dark:text-slate-200 font-semibold mb-2">Legal</h3>
+        <ul class="space-y-1">
+          <li><a href="/legal/privacy.html" class="hover:underline">Privacy Policy</a></li>
+          <li><a href="/legal/terms.html" class="hover:underline">Terms of Service</a></li>
+          <li><a href="/legal/cookie-policy.html" class="hover:underline">Cookie Policy</a></li>
+        </ul>
+      </div>
+      <div class="md:text-right flex items-end">
+        <p class="w-full text-center md:text-right">© <span id="year"></span> AI News Hub</p>
+      </div>
+    </div>
+    <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
+  </footer>
+</body>
+</html>
+

--- a/legal/privacy.html
+++ b/legal/privacy.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Privacy Policy - AI News Hub</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          colors: { primary: '#0ea5e9', secondary: '#06b6d4', dark: '#0f172a', light: '#f8fafc', accent: '#818cf8' },
+          fontFamily: { inter: ['Inter', 'sans-serif'] }
+        }
+      }
+    };
+    if (localStorage.getItem('theme') === 'dark') document.documentElement.classList.add('dark');
+  </script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body class="bg-light dark:bg-dark text-slate-900 dark:text-slate-100 font-inter">
+  <header class="bg-white dark:bg-slate-900 border-b border-slate-200 dark:border-slate-800">
+    <div class="max-w-7xl mx-auto flex justify-between items-center p-4">
+      <a href="/" class="text-xl font-bold">AI News Hub</a>
+      <nav class="flex gap-4 text-sm">
+        <a href="/login.html" class="hover:underline">Sign in</a>
+        <a href="/signup.html" class="hover:underline">Sign up</a>
+      </nav>
+    </div>
+  </header>
+  <main class="max-w-3xl mx-auto p-6">
+    <h1 class="text-3xl font-bold mb-4">Privacy Policy</h1>
+    <section class="space-y-4 text-slate-700 dark:text-slate-300">
+      <p>This is the privacy policy. Replace with real content.</p>
+    </section>
+  </main>
+  <footer class="bg-white dark:bg-slate-900 border-t border-slate-200 dark:border-slate-800 mt-12">
+    <div class="max-w-7xl mx-auto p-8 grid grid-cols-1 md:grid-cols-3 gap-8 text-sm text-slate-500">
+      <div>
+        <h3 class="text-slate-800 dark:text-slate-200 font-semibold mb-2">Resources</h3>
+        <ul class="space-y-1">
+          <li><a href="/resources/glossary.html" class="hover:underline">AI Glossary</a></li>
+          <li><a href="/resources/research.html" class="hover:underline">Research Papers</a></li>
+          <li><a href="/resources/tutorials.html" class="hover:underline">Tutorials</a></li>
+          <li><a href="/resources/events.html" class="hover:underline">Events Calendar</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3 class="text-slate-800 dark:text-slate-200 font-semibold mb-2">Legal</h3>
+        <ul class="space-y-1">
+          <li><a href="/legal/privacy.html" class="hover:underline">Privacy Policy</a></li>
+          <li><a href="/legal/terms.html" class="hover:underline">Terms of Service</a></li>
+          <li><a href="/legal/cookie-policy.html" class="hover:underline">Cookie Policy</a></li>
+        </ul>
+      </div>
+      <div class="md:text-right flex items-end">
+        <p class="w-full text-center md:text-right">© <span id="year"></span> AI News Hub</p>
+      </div>
+    </div>
+    <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
+  </footer>
+</body>
+</html>
+

--- a/legal/terms.html
+++ b/legal/terms.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Terms of Service - AI News Hub</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          colors: { primary: '#0ea5e9', secondary: '#06b6d4', dark: '#0f172a', light: '#f8fafc', accent: '#818cf8' },
+          fontFamily: { inter: ['Inter', 'sans-serif'] }
+        }
+      }
+    };
+    if (localStorage.getItem('theme') === 'dark') document.documentElement.classList.add('dark');
+  </script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body class="bg-light dark:bg-dark text-slate-900 dark:text-slate-100 font-inter">
+  <header class="bg-white dark:bg-slate-900 border-b border-slate-200 dark:border-slate-800">
+    <div class="max-w-7xl mx-auto flex justify-between items-center p-4">
+      <a href="/" class="text-xl font-bold">AI News Hub</a>
+      <nav class="flex gap-4 text-sm">
+        <a href="/login.html" class="hover:underline">Sign in</a>
+        <a href="/signup.html" class="hover:underline">Sign up</a>
+      </nav>
+    </div>
+  </header>
+  <main class="max-w-3xl mx-auto p-6">
+    <h1 class="text-3xl font-bold mb-4">Terms of Service</h1>
+    <section class="space-y-4 text-slate-700 dark:text-slate-300">
+      <p>These are the terms of service. Replace with real content.</p>
+    </section>
+  </main>
+  <footer class="bg-white dark:bg-slate-900 border-t border-slate-200 dark:border-slate-800 mt-12">
+    <div class="max-w-7xl mx-auto p-8 grid grid-cols-1 md:grid-cols-3 gap-8 text-sm text-slate-500">
+      <div>
+        <h3 class="text-slate-800 dark:text-slate-200 font-semibold mb-2">Resources</h3>
+        <ul class="space-y-1">
+          <li><a href="/resources/glossary.html" class="hover:underline">AI Glossary</a></li>
+          <li><a href="/resources/research.html" class="hover:underline">Research Papers</a></li>
+          <li><a href="/resources/tutorials.html" class="hover:underline">Tutorials</a></li>
+          <li><a href="/resources/events.html" class="hover:underline">Events Calendar</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3 class="text-slate-800 dark:text-slate-200 font-semibold mb-2">Legal</h3>
+        <ul class="space-y-1">
+          <li><a href="/legal/privacy.html" class="hover:underline">Privacy Policy</a></li>
+          <li><a href="/legal/terms.html" class="hover:underline">Terms of Service</a></li>
+          <li><a href="/legal/cookie-policy.html" class="hover:underline">Cookie Policy</a></li>
+        </ul>
+      </div>
+      <div class="md:text-right flex items-end">
+        <p class="w-full text-center md:text-right">© <span id="year"></span> AI News Hub</p>
+      </div>
+    </div>
+    <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
+  </footer>
+</body>
+</html>
+

--- a/login.html
+++ b/login.html
@@ -1,25 +1,136 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="scroll-smooth">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Login - AI News Hub</title>
+  <title>Sign in - AI News Hub</title>
   <script src="https://cdn.tailwindcss.com"></script>
-  <script>window.NEXT_PUBLIC_HAS_OAUTH = process.env.NEXT_PUBLIC_HAS_OAUTH === 'true';</script>
-</head>
-<body class="bg-light dark:bg-dark">
-  <main class="max-w-md mx-auto p-6 text-center">
-    <h1 class="text-2xl font-bold mb-6">Login</h1>
-    <a id="google-login" href="/api/auth/oauth/google" class="block w-full bg-primary text-white px-4 py-2 rounded mb-4">Login with Google</a>
-    <a href="/api/auth/oauth/github" class="block w-full bg-gray-800 text-white px-4 py-2 rounded">Login with GitHub</a>
-  </main>
   <script>
-    if (!window.NEXT_PUBLIC_HAS_OAUTH) {
-      const btn = document.getElementById('google-login');
-      if (btn) {
-        btn.classList.add('hidden');
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          colors: {
+            primary: '#0ea5e9',
+            secondary: '#06b6d4',
+            dark: '#0f172a',
+            light: '#f8fafc',
+            accent: '#818cf8'
+          },
+          fontFamily: {
+            inter: ['Inter', 'sans-serif']
+          }
+        }
       }
-    }
+    };
+    if (localStorage.getItem('theme') === 'dark') document.documentElement.classList.add('dark');
+  </script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+</head>
+<body class="bg-light dark:bg-dark text-slate-900 dark:text-slate-100 font-inter">
+  <header class="bg-white dark:bg-slate-900 border-b border-slate-200 dark:border-slate-800">
+    <div class="max-w-7xl mx-auto flex justify-between items-center p-4">
+      <a href="/" class="text-xl font-bold">AI News Hub</a>
+      <nav class="flex gap-4 text-sm">
+        <a href="/login.html" class="hover:underline">Sign in</a>
+        <a href="/signup.html" class="hover:underline">Sign up</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="min-h-[calc(100vh-160px)] flex items-center justify-center p-4">
+    <div class="w-full max-w-md bg-white dark:bg-slate-900 rounded-lg shadow p-6">
+      <h1 class="text-2xl font-bold mb-6 text-center">Sign in</h1>
+      <form id="login-form" class="space-y-4">
+        <div>
+          <label for="email" class="block mb-1 text-left">Email</label>
+          <input id="email" name="email" type="email" class="w-full border rounded p-2" required />
+        </div>
+        <div>
+          <label for="password" class="block mb-1 text-left">Password</label>
+          <input id="password" name="password" type="password" class="w-full border rounded p-2" required />
+        </div>
+        <div class="flex items-center">
+          <input id="remember" name="remember" type="checkbox" class="mr-2" />
+          <label for="remember">Keep me signed in</label>
+        </div>
+        <button id="login-submit" type="submit" class="w-full bg-primary text-white py-2 rounded disabled:opacity-50">Sign in</button>
+        <p id="login-error" class="text-red-600 text-sm"></p>
+      </form>
+      <div class="my-4 flex items-center">
+        <hr class="flex-grow border-slate-300" />
+        <span class="px-2 text-slate-500 text-sm">or</span>
+        <hr class="flex-grow border-slate-300" />
+      </div>
+      <button id="google-btn" class="w-full border flex items-center justify-center gap-2 py-2 rounded hover:bg-slate-50 dark:hover:bg-slate-800"><i class="fa-brands fa-google"></i><span>Continue with Google</span></button>
+      <p class="mt-4 text-center text-sm">No account? <a href="/signup.html" class="text-primary hover:underline">Sign up</a></p>
+    </div>
+  </main>
+
+  <footer class="bg-white dark:bg-slate-900 border-t border-slate-200 dark:border-slate-800 mt-12">
+    <div class="max-w-7xl mx-auto p-8 grid grid-cols-1 md:grid-cols-3 gap-8 text-sm text-slate-500">
+      <div>
+        <h3 class="text-slate-800 dark:text-slate-200 font-semibold mb-2">Resources</h3>
+        <ul class="space-y-1">
+          <li><a href="/resources/glossary.html" class="hover:underline">AI Glossary</a></li>
+          <li><a href="/resources/research.html" class="hover:underline">Research Papers</a></li>
+          <li><a href="/resources/tutorials.html" class="hover:underline">Tutorials</a></li>
+          <li><a href="/resources/events.html" class="hover:underline">Events Calendar</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3 class="text-slate-800 dark:text-slate-200 font-semibold mb-2">Legal</h3>
+        <ul class="space-y-1">
+          <li><a href="/legal/privacy.html" class="hover:underline">Privacy Policy</a></li>
+          <li><a href="/legal/terms.html" class="hover:underline">Terms of Service</a></li>
+          <li><a href="/legal/cookie-policy.html" class="hover:underline">Cookie Policy</a></li>
+        </ul>
+      </div>
+      <div class="md:text-right flex items-end">
+        <p class="w-full text-center md:text-right">© <span id="year"></span> AI News Hub</p>
+      </div>
+    </div>
+    <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
+  </footer>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const form = document.getElementById('login-form');
+      const errorEl = document.getElementById('login-error');
+      const btn = document.getElementById('login-submit');
+      document.getElementById('google-btn').addEventListener('click', () => {
+        window.location.href = '/api/auth/oauth/google?provider=google';
+      });
+      form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        errorEl.textContent = '';
+        btn.disabled = true;
+        const payload = {
+          email: document.getElementById('email').value.trim(),
+          password: document.getElementById('password').value,
+          remember: document.getElementById('remember').checked,
+        };
+        try {
+          const res = await fetch('/api/auth/login', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+          });
+          if (res.ok) {
+            window.location.href = '/';
+          } else {
+            const out = await res.json().catch(() => ({}));
+            errorEl.textContent = out.error || 'Sign in failed';
+          }
+        } catch {
+          errorEl.textContent = 'Sign in failed';
+        } finally {
+          btn.disabled = false;
+        }
+      });
+    });
   </script>
 </body>
 </html>
+

--- a/resources/events.html
+++ b/resources/events.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Events Calendar - AI News Hub</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          colors: { primary: '#0ea5e9', secondary: '#06b6d4', dark: '#0f172a', light: '#f8fafc', accent: '#818cf8' },
+          fontFamily: { inter: ['Inter', 'sans-serif'] }
+        }
+      }
+    };
+    if (localStorage.getItem('theme') === 'dark') document.documentElement.classList.add('dark');
+  </script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body class="bg-light dark:bg-dark text-slate-900 dark:text-slate-100 font-inter">
+  <header class="bg-white dark:bg-slate-900 border-b border-slate-200 dark:border-slate-800">
+    <div class="max-w-7xl mx-auto flex justify-between items-center p-4">
+      <a href="/" class="text-xl font-bold">AI News Hub</a>
+      <nav class="flex gap-4 text-sm">
+        <a href="/login.html" class="hover:underline">Sign in</a>
+        <a href="/signup.html" class="hover:underline">Sign up</a>
+      </nav>
+    </div>
+  </header>
+  <main class="max-w-3xl mx-auto p-6">
+    <h1 class="text-3xl font-bold mb-4">Events Calendar</h1>
+    <section class="space-y-4 text-slate-700 dark:text-slate-300">
+      <p>Events content goes here.</p>
+    </section>
+  </main>
+  <footer class="bg-white dark:bg-slate-900 border-t border-slate-200 dark:border-slate-800 mt-12">
+    <div class="max-w-7xl mx-auto p-8 grid grid-cols-1 md:grid-cols-3 gap-8 text-sm text-slate-500">
+      <div>
+        <h3 class="text-slate-800 dark:text-slate-200 font-semibold mb-2">Resources</h3>
+        <ul class="space-y-1">
+          <li><a href="/resources/glossary.html" class="hover:underline">AI Glossary</a></li>
+          <li><a href="/resources/research.html" class="hover:underline">Research Papers</a></li>
+          <li><a href="/resources/tutorials.html" class="hover:underline">Tutorials</a></li>
+          <li><a href="/resources/events.html" class="hover:underline">Events Calendar</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3 class="text-slate-800 dark:text-slate-200 font-semibold mb-2">Legal</h3>
+        <ul class="space-y-1">
+          <li><a href="/legal/privacy.html" class="hover:underline">Privacy Policy</a></li>
+          <li><a href="/legal/terms.html" class="hover:underline">Terms of Service</a></li>
+          <li><a href="/legal/cookie-policy.html" class="hover:underline">Cookie Policy</a></li>
+        </ul>
+      </div>
+      <div class="md:text-right flex items-end">
+        <p class="w-full text-center md:text-right">© <span id="year"></span> AI News Hub</p>
+      </div>
+    </div>
+    <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
+  </footer>
+</body>
+</html>
+

--- a/resources/glossary.html
+++ b/resources/glossary.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>AI Glossary - AI News Hub</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          colors: { primary: '#0ea5e9', secondary: '#06b6d4', dark: '#0f172a', light: '#f8fafc', accent: '#818cf8' },
+          fontFamily: { inter: ['Inter', 'sans-serif'] }
+        }
+      }
+    };
+    if (localStorage.getItem('theme') === 'dark') document.documentElement.classList.add('dark');
+  </script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body class="bg-light dark:bg-dark text-slate-900 dark:text-slate-100 font-inter">
+  <header class="bg-white dark:bg-slate-900 border-b border-slate-200 dark:border-slate-800">
+    <div class="max-w-7xl mx-auto flex justify-between items-center p-4">
+      <a href="/" class="text-xl font-bold">AI News Hub</a>
+      <nav class="flex gap-4 text-sm">
+        <a href="/login.html" class="hover:underline">Sign in</a>
+        <a href="/signup.html" class="hover:underline">Sign up</a>
+      </nav>
+    </div>
+  </header>
+  <main class="max-w-3xl mx-auto p-6">
+    <h1 class="text-3xl font-bold mb-4">AI Glossary</h1>
+    <section class="space-y-4 text-slate-700 dark:text-slate-300">
+      <p>Glossary content goes here.</p>
+    </section>
+  </main>
+  <footer class="bg-white dark:bg-slate-900 border-t border-slate-200 dark:border-slate-800 mt-12">
+    <div class="max-w-7xl mx-auto p-8 grid grid-cols-1 md:grid-cols-3 gap-8 text-sm text-slate-500">
+      <div>
+        <h3 class="text-slate-800 dark:text-slate-200 font-semibold mb-2">Resources</h3>
+        <ul class="space-y-1">
+          <li><a href="/resources/glossary.html" class="hover:underline">AI Glossary</a></li>
+          <li><a href="/resources/research.html" class="hover:underline">Research Papers</a></li>
+          <li><a href="/resources/tutorials.html" class="hover:underline">Tutorials</a></li>
+          <li><a href="/resources/events.html" class="hover:underline">Events Calendar</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3 class="text-slate-800 dark:text-slate-200 font-semibold mb-2">Legal</h3>
+        <ul class="space-y-1">
+          <li><a href="/legal/privacy.html" class="hover:underline">Privacy Policy</a></li>
+          <li><a href="/legal/terms.html" class="hover:underline">Terms of Service</a></li>
+          <li><a href="/legal/cookie-policy.html" class="hover:underline">Cookie Policy</a></li>
+        </ul>
+      </div>
+      <div class="md:text-right flex items-end">
+        <p class="w-full text-center md:text-right">© <span id="year"></span> AI News Hub</p>
+      </div>
+    </div>
+    <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
+  </footer>
+</body>
+</html>
+

--- a/resources/research.html
+++ b/resources/research.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Research Papers - AI News Hub</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          colors: { primary: '#0ea5e9', secondary: '#06b6d4', dark: '#0f172a', light: '#f8fafc', accent: '#818cf8' },
+          fontFamily: { inter: ['Inter', 'sans-serif'] }
+        }
+      }
+    };
+    if (localStorage.getItem('theme') === 'dark') document.documentElement.classList.add('dark');
+  </script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body class="bg-light dark:bg-dark text-slate-900 dark:text-slate-100 font-inter">
+  <header class="bg-white dark:bg-slate-900 border-b border-slate-200 dark:border-slate-800">
+    <div class="max-w-7xl mx-auto flex justify-between items-center p-4">
+      <a href="/" class="text-xl font-bold">AI News Hub</a>
+      <nav class="flex gap-4 text-sm">
+        <a href="/login.html" class="hover:underline">Sign in</a>
+        <a href="/signup.html" class="hover:underline">Sign up</a>
+      </nav>
+    </div>
+  </header>
+  <main class="max-w-3xl mx-auto p-6">
+    <h1 class="text-3xl font-bold mb-4">Research Papers</h1>
+    <section class="space-y-4 text-slate-700 dark:text-slate-300">
+      <p>Research content goes here.</p>
+    </section>
+  </main>
+  <footer class="bg-white dark:bg-slate-900 border-t border-slate-200 dark:border-slate-800 mt-12">
+    <div class="max-w-7xl mx-auto p-8 grid grid-cols-1 md:grid-cols-3 gap-8 text-sm text-slate-500">
+      <div>
+        <h3 class="text-slate-800 dark:text-slate-200 font-semibold mb-2">Resources</h3>
+        <ul class="space-y-1">
+          <li><a href="/resources/glossary.html" class="hover:underline">AI Glossary</a></li>
+          <li><a href="/resources/research.html" class="hover:underline">Research Papers</a></li>
+          <li><a href="/resources/tutorials.html" class="hover:underline">Tutorials</a></li>
+          <li><a href="/resources/events.html" class="hover:underline">Events Calendar</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3 class="text-slate-800 dark:text-slate-200 font-semibold mb-2">Legal</h3>
+        <ul class="space-y-1">
+          <li><a href="/legal/privacy.html" class="hover:underline">Privacy Policy</a></li>
+          <li><a href="/legal/terms.html" class="hover:underline">Terms of Service</a></li>
+          <li><a href="/legal/cookie-policy.html" class="hover:underline">Cookie Policy</a></li>
+        </ul>
+      </div>
+      <div class="md:text-right flex items-end">
+        <p class="w-full text-center md:text-right">© <span id="year"></span> AI News Hub</p>
+      </div>
+    </div>
+    <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
+  </footer>
+</body>
+</html>
+

--- a/resources/tutorials.html
+++ b/resources/tutorials.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Tutorials - AI News Hub</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          colors: { primary: '#0ea5e9', secondary: '#06b6d4', dark: '#0f172a', light: '#f8fafc', accent: '#818cf8' },
+          fontFamily: { inter: ['Inter', 'sans-serif'] }
+        }
+      }
+    };
+    if (localStorage.getItem('theme') === 'dark') document.documentElement.classList.add('dark');
+  </script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body class="bg-light dark:bg-dark text-slate-900 dark:text-slate-100 font-inter">
+  <header class="bg-white dark:bg-slate-900 border-b border-slate-200 dark:border-slate-800">
+    <div class="max-w-7xl mx-auto flex justify-between items-center p-4">
+      <a href="/" class="text-xl font-bold">AI News Hub</a>
+      <nav class="flex gap-4 text-sm">
+        <a href="/login.html" class="hover:underline">Sign in</a>
+        <a href="/signup.html" class="hover:underline">Sign up</a>
+      </nav>
+    </div>
+  </header>
+  <main class="max-w-3xl mx-auto p-6">
+    <h1 class="text-3xl font-bold mb-4">Tutorials</h1>
+    <section class="space-y-4 text-slate-700 dark:text-slate-300">
+      <p>Tutorial content goes here.</p>
+    </section>
+  </main>
+  <footer class="bg-white dark:bg-slate-900 border-t border-slate-200 dark:border-slate-800 mt-12">
+    <div class="max-w-7xl mx-auto p-8 grid grid-cols-1 md:grid-cols-3 gap-8 text-sm text-slate-500">
+      <div>
+        <h3 class="text-slate-800 dark:text-slate-200 font-semibold mb-2">Resources</h3>
+        <ul class="space-y-1">
+          <li><a href="/resources/glossary.html" class="hover:underline">AI Glossary</a></li>
+          <li><a href="/resources/research.html" class="hover:underline">Research Papers</a></li>
+          <li><a href="/resources/tutorials.html" class="hover:underline">Tutorials</a></li>
+          <li><a href="/resources/events.html" class="hover:underline">Events Calendar</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3 class="text-slate-800 dark:text-slate-200 font-semibold mb-2">Legal</h3>
+        <ul class="space-y-1">
+          <li><a href="/legal/privacy.html" class="hover:underline">Privacy Policy</a></li>
+          <li><a href="/legal/terms.html" class="hover:underline">Terms of Service</a></li>
+          <li><a href="/legal/cookie-policy.html" class="hover:underline">Cookie Policy</a></li>
+        </ul>
+      </div>
+      <div class="md:text-right flex items-end">
+        <p class="w-full text-center md:text-right">© <span id="year"></span> AI News Hub</p>
+      </div>
+    </div>
+    <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
+  </footer>
+</body>
+</html>
+

--- a/signup.html
+++ b/signup.html
@@ -3,73 +3,150 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Sign Up - AI News Hub</title>
-  <!-- Tailwind & Icons -->
+  <title>Create account - AI News Hub</title>
   <script src="https://cdn.tailwindcss.com"></script>
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-  <style>
-    :root{--primary:#0ea5e9;--secondary:#06b6d4;--dark:#0f172a;--light:#f8fafc;--accent:#818cf8;}
-    body{font-family:'Inter',sans-serif;background:#f8fafc;color:#0f172a;}
-  </style>
-</head>
-<body class="bg-light dark:bg-dark">
-  <main class="max-w-md mx-auto p-6">
-    <h1 class="text-2xl font-bold mb-6 text-center">Sign Up</h1>
-    <form id="signup-form" class="space-y-4">
-      <input id="name" type="text" placeholder="Name" class="w-full border rounded p-2" required />
-      <input id="email" type="email" placeholder="Email" class="w-full border rounded p-2" required />
-      <input id="password" type="password" placeholder="Password" class="w-full border rounded p-2" required />
-      <button type="submit" class="w-full bg-primary text-white px-4 py-2 rounded">Create Account</button>
-      <p id="error-message" class="text-red-600"></p>
-    </form>
-  </main>
   <script>
-    function getCsrfToken(){
-      const m=document.cookie.match(/(?:^|;)\s*csrf=([^;]+)/);
-      if(!m) return '';
-      return decodeURIComponent(m[1]).split('.')[0];
-    }
-    document.addEventListener('DOMContentLoaded', async () => {
-      try { await fetch('/api/auth/signup', { credentials: 'include' }); } catch (e) {}
-      const form=document.getElementById('signup-form');
-      const errorEl=document.getElementById('error-message');
-      const btn=form.querySelector('button');
-      form.addEventListener('submit', async (e)=>{
-        e.preventDefault();
-        errorEl.textContent='';
-        const name=document.getElementById('name').value.trim();
-        const email=document.getElementById('email').value.trim();
-        const password=document.getElementById('password').value;
-        const csrfToken=getCsrfToken();
-        btn.disabled=true;
-        const originalHTML=btn.innerHTML;
-        btn.innerHTML='<i class="fas fa-spinner fa-spin mr-2"></i> Creating...';
-        try{
-          const res=await fetch('/api/auth/signup',{
-            method:'POST',
-            headers:{'Content-Type':'application/json','X-CSRF-Token':csrfToken},
-            credentials:'include',
-            body:JSON.stringify({name,email,password})
-          });
-          if(res.ok){
-            window.location.href='/';
-          }else{
-            let msg='Signup failed';
-            try{
-              const data=await res.json();
-              msg=data.error||msg;
-            }catch{}
-            errorEl.textContent=msg;
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          colors: {
+            primary: '#0ea5e9',
+            secondary: '#06b6d4',
+            dark: '#0f172a',
+            light: '#f8fafc',
+            accent: '#818cf8'
+          },
+          fontFamily: {
+            inter: ['Inter', 'sans-serif']
           }
-        }catch{
-          errorEl.textContent='Signup failed';
-        }finally{
-          btn.disabled=false;
-          btn.innerHTML=originalHTML;
+        }
+      }
+    };
+    if (localStorage.getItem('theme') === 'dark') document.documentElement.classList.add('dark');
+  </script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+</head>
+<body class="bg-light dark:bg-dark text-slate-900 dark:text-slate-100 font-inter">
+  <header class="bg-white dark:bg-slate-900 border-b border-slate-200 dark:border-slate-800">
+    <div class="max-w-7xl mx-auto flex justify-between items-center p-4">
+      <a href="/" class="text-xl font-bold">AI News Hub</a>
+      <nav class="flex gap-4 text-sm">
+        <a href="/login.html" class="hover:underline">Sign in</a>
+        <a href="/signup.html" class="hover:underline">Sign up</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="min-h-[calc(100vh-160px)] flex items-center justify-center p-4">
+    <div class="w-full max-w-md bg-white dark:bg-slate-900 rounded-lg shadow p-6">
+      <h1 class="text-2xl font-bold mb-6 text-center">Create account</h1>
+      <form id="signup-form" class="space-y-4">
+        <div>
+          <label for="name" class="block mb-1 text-left">Name (optional)</label>
+          <input id="name" name="name" type="text" class="w-full border rounded p-2" />
+        </div>
+        <div>
+          <label for="email" class="block mb-1 text-left">Email</label>
+          <input id="email" name="email" type="email" class="w-full border rounded p-2" required />
+        </div>
+        <div>
+          <label for="password" class="block mb-1 text-left">Password</label>
+          <input id="password" name="password" type="password" class="w-full border rounded p-2" required />
+        </div>
+        <div>
+          <label for="confirmPassword" class="block mb-1 text-left">Confirm password</label>
+          <input id="confirmPassword" name="confirmPassword" type="password" class="w-full border rounded p-2" required />
+        </div>
+        <div class="flex items-center">
+          <input id="terms" type="checkbox" class="mr-2" />
+          <label for="terms" class="text-sm">I accept the <a href="/legal/terms.html" class="text-primary hover:underline">Terms</a> and <a href="/legal/privacy.html" class="text-primary hover:underline">Privacy Policy</a></label>
+        </div>
+        <button id="signup-submit" type="submit" class="w-full bg-primary text-white py-2 rounded disabled:opacity-50">Create account</button>
+        <p id="signup-error" class="text-red-600 text-sm"></p>
+      </form>
+      <div class="my-4 flex items-center">
+        <hr class="flex-grow border-slate-300" />
+        <span class="px-2 text-slate-500 text-sm">or</span>
+        <hr class="flex-grow border-slate-300" />
+      </div>
+      <button id="google-signup" class="w-full border flex items-center justify-center gap-2 py-2 rounded hover:bg-slate-50 dark:hover:bg-slate-800"><i class="fa-brands fa-google"></i><span>Sign up with Google</span></button>
+      <p class="mt-4 text-center text-sm">Already have an account? <a href="/login.html" class="text-primary hover:underline">Sign in</a></p>
+    </div>
+  </main>
+
+  <footer class="bg-white dark:bg-slate-900 border-t border-slate-200 dark:border-slate-800 mt-12">
+    <div class="max-w-7xl mx-auto p-8 grid grid-cols-1 md:grid-cols-3 gap-8 text-sm text-slate-500">
+      <div>
+        <h3 class="text-slate-800 dark:text-slate-200 font-semibold mb-2">Resources</h3>
+        <ul class="space-y-1">
+          <li><a href="/resources/glossary.html" class="hover:underline">AI Glossary</a></li>
+          <li><a href="/resources/research.html" class="hover:underline">Research Papers</a></li>
+          <li><a href="/resources/tutorials.html" class="hover:underline">Tutorials</a></li>
+          <li><a href="/resources/events.html" class="hover:underline">Events Calendar</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3 class="text-slate-800 dark:text-slate-200 font-semibold mb-2">Legal</h3>
+        <ul class="space-y-1">
+          <li><a href="/legal/privacy.html" class="hover:underline">Privacy Policy</a></li>
+          <li><a href="/legal/terms.html" class="hover:underline">Terms of Service</a></li>
+          <li><a href="/legal/cookie-policy.html" class="hover:underline">Cookie Policy</a></li>
+        </ul>
+      </div>
+      <div class="md:text-right flex items-end">
+        <p class="w-full text-center md:text-right">© <span id="year"></span> AI News Hub</p>
+      </div>
+    </div>
+    <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
+  </footer>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const form = document.getElementById('signup-form');
+      const btn = document.getElementById('signup-submit');
+      const errorEl = document.getElementById('signup-error');
+      document.getElementById('google-signup').addEventListener('click', () => {
+        window.location.href = '/api/auth/oauth/google?provider=google';
+      });
+      form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        errorEl.textContent = '';
+        if (document.getElementById('password').value !== document.getElementById('confirmPassword').value) {
+          errorEl.textContent = 'Passwords do not match';
+          return;
+        }
+        if (!document.getElementById('terms').checked) {
+          errorEl.textContent = 'You must accept the Terms and Privacy Policy';
+          return;
+        }
+        btn.disabled = true;
+        const payload = {
+          name: document.getElementById('name').value.trim(),
+          email: document.getElementById('email').value.trim(),
+          password: document.getElementById('password').value,
+        };
+        try {
+          const res = await fetch('/api/auth/signup', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+          });
+          if (res.ok) {
+            window.location.href = '/';
+          } else {
+            const out = await res.json().catch(() => ({}));
+            errorEl.textContent = out.error || 'Signup failed';
+          }
+        } catch {
+          errorEl.textContent = 'Signup failed';
+        } finally {
+          btn.disabled = false;
         }
       });
     });
   </script>
 </body>
 </html>
+

--- a/tests/oauth-authorize-path.test.js
+++ b/tests/oauth-authorize-path.test.js
@@ -12,6 +12,8 @@ test('authorize URL uses project-scoped auth path', async () => {
   const res = {
     setHeader() {},
     writeHead(code, h) { status = code; headers = h; return this; },
+    status(code) { status = code; return this; },
+    json() {},
     end() {},
   };
   await handler(req, res);


### PR DESCRIPTION
## Summary
- add standalone sign in/sign up pages with email/password forms and Google buttons
- stub login and signup API routes issuing session cookies
- add legal and resource pages and wire navigation

## Testing
- `npm test`

