### PR TITLE
Use cookie parser for OAuth callback and tighten OAuth params

### DIFF
--- a/api/auth/callback.js
+++ b/api/auth/callback.js
@@ -1,5 +1,6 @@
 // pages/api/auth/callback.js
 const { ensureConfig } = require('../../../lib/auth');
+const { parse } = require('cookie');
 
 /**
  * Notes (Shared keys OFF):
@@ -25,16 +26,7 @@ module.exports = async (req, res) => {
     if (!state) return res.status(400).json({ error: 'missing_state' });
 
     // Read & clear PKCE + state from cookies
-    const cookies = Object.fromEntries(
-      (req.headers.cookie || '')
-        .split(';')
-        .map(v => v.trim())
-        .filter(Boolean)
-        .map(v => {
-          const i = v.indexOf('=');
-          return [v.slice(0, i), decodeURIComponent(v.slice(i + 1))];
-        })
-    );
+    const cookies = parse(req.headers.cookie || '');
 
     const cookieState = cookies['oauth_state'];
     const codeVerifier = cookies['pkce_verifier'];

--- a/api/auth/oauth/[provider].js
+++ b/api/auth/oauth/[provider].js
@@ -13,7 +13,7 @@ module.exports = async (req, res) => {
 
   try {
     // Public key only (pck_…)
-    ensureConfig(['STACK_AUTH_CLIENT_ID']);
+    ensureConfig(['STACK_AUTH_PROJECT_ID', 'STACK_AUTH_CLIENT_ID']);
 
     const provider = req.query.provider;
     if (!provider) return res.status(400).json({ error: 'missing_provider' });
@@ -32,18 +32,16 @@ module.exports = async (req, res) => {
       `oauth_state=${state}; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=600`
     ]);
 
+    const projectId = process.env.STACK_AUTH_PROJECT_ID;
     const clientId = process.env.STACK_AUTH_CLIENT_ID; // pck_…
 
-    const url = new URL(`https://api.stack-auth.com/api/v1/auth/oauth/authorize/${encodeURIComponent(provider)}`);
+    const url = new URL(`https://api.stack-auth.com/api/v1/projects/${encodeURIComponent(projectId)}/auth/oauth/authorize/${encodeURIComponent(provider)}`);
     url.searchParams.set('client_id', clientId);
     url.searchParams.set('redirect_uri', redirectUri);
     url.searchParams.set('response_type', 'code');
 
     // IMPORTANT: this must match the scopes configured for the provider in Stack Auth.
-    // If your provider page shows short scopes, use this:
     url.searchParams.set('scope', 'openid email profile');
-    // If you explicitly configured long Google scopes there, use:
-    // url.searchParams.set('scope', 'openid https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile');
 
     url.searchParams.set('code_challenge_method', 'S256');
     url.searchParams.set('code_challenge', challenge);

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",
+    "cookie": "^1.0.2",
     "jose": "^5.10.0",
     "pg": "^8.11.3"
   },

--- a/tests/oauth-authorize-path.test.js
+++ b/tests/oauth-authorize-path.test.js
@@ -20,6 +20,8 @@ test('authorize URL uses project-scoped auth path', async () => {
   assert.strictEqual(status, 302);
   const url = new URL(headers.Location);
   assert.strictEqual(url.pathname, '/api/v1/projects/proj/auth/oauth/authorize/google');
+  assert.ok(!url.searchParams.has('client_secret'));
+  assert.ok(!url.searchParams.has('grant_type'));
 });
 
 test.after(() => {


### PR DESCRIPTION
## Summary
- parse PKCE/state cookies using `cookie` instead of manual logic
- scope Stack Auth authorize requests to project ID and ensure correct Google scope
- add tests forbidding `client_secret` or `grant_type` in authorize URLs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c944363b48328bae17830ff5e6f7a