### PR TITLE
chore: remove obsolete auth endpoints

### DIFF
--- a/api/auth/[...auth0].js
+++ b/api/auth/[...auth0].js
@@ -1,2 +1,0 @@
-const { handleAuth } = require('@auth0/nextjs-auth0');
-module.exports = handleAuth();


### PR DESCRIPTION
## Summary
- remove deprecated Auth0 callback under `api/auth`

## Testing
- `npm test`


