### PR TITLE
refactor: update auth endpoints

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -60,7 +60,7 @@
 
     async function ensureCsrfCookie() {
         if (!getCsrfToken()) {
-          await fetch('/api/auth/signup', { credentials: 'include' });
+          await fetch('/api/auth/csrf', { credentials: 'include' });
         }
     }
 

--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
             <div id="user-info" class="hidden items-center gap-2">
               <span id="user-name" class="font-medium"></span>
               <a id="admin-link" href="/admin.html" class="hidden px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Admin</a>
-            <a id="logout-link" href="/api/auth/signout" class="px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Logout</a>
+            <a id="logout-link" href="/api/auth/logout" class="px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Logout</a>
             </div>
           </div>
 

--- a/login/index.html
+++ b/login/index.html
@@ -42,7 +42,7 @@
   <main class="min-h-[calc(100vh-160px)] flex items-center justify-center p-4">
     <div class="w-full max-w-md bg-white dark:bg-slate-900 rounded-lg shadow p-6">
       <h1 class="text-2xl font-bold mb-6 text-center">Sign in</h1>
-      <form id="login-form" class="space-y-4" method="post" action="/api/auth/callback/credentials">
+      <form id="login-form" class="space-y-4" method="post">
         <input type="hidden" name="csrfToken" id="csrfToken" />
         <div>
           <label for="email" class="block mb-1 text-left">Email</label>
@@ -96,7 +96,7 @@
 
   <script>
     document.getElementById('google-btn').addEventListener('click', () => {
-      window.location.href = '/api/auth/signin/google';
+      window.location.href = '/api/auth/login?connection=google-oauth2';
     });
     fetch('/api/auth/csrf').then(r => r.json()).then(d => {
       document.getElementById('csrfToken').value = d.csrfToken;

--- a/post.html
+++ b/post.html
@@ -31,7 +31,7 @@
 
     async function ensureCsrfCookie() {
         if (!getCsrfToken()) {
-          await fetch('/api/auth/signup', { credentials: 'include' });
+          await fetch('/api/auth/csrf', { credentials: 'include' });
         }
     }
 

--- a/signup/index.html
+++ b/signup/index.html
@@ -105,45 +105,13 @@
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       const form = document.getElementById('signup-form');
-      const btn = document.getElementById('signup-submit');
       const errorEl = document.getElementById('signup-error');
       document.getElementById('google-signup').addEventListener('click', () => {
-        window.location.href = '/api/auth/signin/google';
+        window.location.href = '/api/auth/login?connection=google-oauth2';
       });
-      form.addEventListener('submit', async (e) => {
+      form.addEventListener('submit', (e) => {
         e.preventDefault();
-        errorEl.textContent = '';
-        if (document.getElementById('password').value !== document.getElementById('confirmPassword').value) {
-          errorEl.textContent = 'Passwords do not match';
-          return;
-        }
-        if (!document.getElementById('terms').checked) {
-          errorEl.textContent = 'You must accept the Terms and Privacy Policy';
-          return;
-        }
-        btn.disabled = true;
-        const payload = {
-          name: document.getElementById('name').value.trim(),
-          email: document.getElementById('email').value.trim(),
-          password: document.getElementById('password').value,
-        };
-        try {
-          const res = await fetch('/api/auth/signup', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(payload),
-          });
-          if (res.ok) {
-            window.location.href = '/';
-          } else {
-            const out = await res.json().catch(() => ({}));
-            errorEl.textContent = out.error || 'Signup failed';
-          }
-        } catch {
-          errorEl.textContent = 'Signup failed';
-        } finally {
-          btn.disabled = false;
-        }
+        errorEl.textContent = 'Signup is currently unavailable.';
       });
     });
   </script>


### PR DESCRIPTION
## Summary
- update google sign-in to `/api/auth/login?connection=google-oauth2`
- use `/api/auth/logout` for sign-out link
- remove deprecated signup and credentials callback endpoints

## Testing
- `npm test`

