### PR TITLE
docs: replace stack auth with auth0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 - Dateien: `api/**`
 - DB: Postgres (Neon), Tabelle `public.posts`
 - Spalten (wichtig): id, slug (unique), title, excerpt, content, category, tags text[], author, image_url, published_at timestamptz default now()
-- ENV: `DATABASE_URL` (SSL), `STACK_AUTH_PROJECT_ID`, `STACK_AUTH_CLIENT_ID`, `STACK_AUTH_CLIENT_SECRET`
+- ENV: `DATABASE_URL` (SSL), `AUTH0_SECRET`, `AUTH0_BASE_URL`, `AUTH0_CLIENT_ID`, `AUTH0_CLIENT_SECRET`, `AUTH0_ISSUER_BASE_URL`
 
 ## Regeln
 - Keine breaking Schema-Änderungen ohne Migration

--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@
 Create a `.env` file and provide the following variables:
 
 - `DATABASE_URL` – Postgres connection string (Neon requires SSL)
-- `STACK_AUTH_PROJECT_ID` – Stack Auth project identifier
-- `STACK_AUTH_CLIENT_ID` – Stack Auth client ID
-- `STACK_AUTH_CLIENT_SECRET` – Stack Auth client secret
+- `AUTH0_SECRET` – Auth0 session secret
+- `AUTH0_BASE_URL` – Base URL of this app
+- `AUTH0_CLIENT_ID` – Auth0 application client ID
+- `AUTH0_CLIENT_SECRET` – Auth0 application client secret
+- `AUTH0_ISSUER_BASE_URL` – Auth0 issuer URL
 
 ## Database Setup (Neon)
 

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,4 +1,11 @@
-const REQUIRED_KEYS = ['DATABASE_URL','STACK_AUTH_PROJECT_ID','STACK_AUTH_CLIENT_ID','STACK_AUTH_CLIENT_SECRET'];
+const REQUIRED_KEYS = [
+  'DATABASE_URL',
+  'AUTH0_SECRET',
+  'AUTH0_BASE_URL',
+  'AUTH0_CLIENT_ID',
+  'AUTH0_CLIENT_SECRET',
+  'AUTH0_ISSUER_BASE_URL'
+];
 
 class ConfigError extends Error {
   constructor(missing) { super(`Missing environment variables: ${missing.join(', ')}`); this.code = 'CONFIG_ERROR'; }


### PR DESCRIPTION
## Summary
- document Auth0 environment variables in README and AGENTS
- require Auth0 config in server helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d19801f548328a690f356e62e4b60