### PR TITLE
test: verify login and legal pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "pg": "^8.11.3"
       },
       "devDependencies": {
-        "pg-mem": "^3.0.5"
+        "pg-mem": "^3.0.5",
+        "undici": "^7.13.0"
       }
     },
     "node_modules/@auth0/nextjs-auth0": {
@@ -1744,6 +1745,16 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/undici": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.13.0.tgz",
+      "integrity": "sha512-l+zSMssRqrzDcb3fjMkjjLGmuiiK2pMIcV++mJaAc9vhjSGpvM7h43QgP+OAMb1GImHmbPyG2tBXeuyG5iY4gA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/url-join": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -7,10 +7,11 @@
     "test": "node --test"
   },
   "dependencies": {
-    "pg": "^8.11.3",
-    "@auth0/nextjs-auth0": "^3"
+    "@auth0/nextjs-auth0": "^3",
+    "pg": "^8.11.3"
   },
   "devDependencies": {
-    "pg-mem": "^3.0.5"
+    "pg-mem": "^3.0.5",
+    "undici": "^7.13.0"
   }
 }

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -1,0 +1,68 @@
+const { test, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const { createServer } = require('node:http');
+const { readFile, stat } = require('node:fs/promises');
+const { join } = require('node:path');
+const { once } = require('node:events');
+const { fetch } = require('undici');
+
+let server;
+let base;
+
+before(async () => {
+  server = createServer(async (req, res) => {
+    try {
+      const url = new URL(req.url, 'http://localhost');
+      let filePath = join(process.cwd(), url.pathname);
+      try {
+        const stats = await stat(filePath);
+        if (stats.isDirectory()) {
+          filePath = join(filePath, 'index.html');
+        }
+      } catch {
+        try {
+          await stat(filePath + '.html');
+          filePath = filePath + '.html';
+        } catch {
+          res.statusCode = 404;
+          res.end('Not Found');
+          return;
+        }
+      }
+      const data = await readFile(filePath);
+      res.statusCode = 200;
+      res.setHeader('content-type', 'text/html; charset=utf-8');
+      res.end(data);
+    } catch (err) {
+      res.statusCode = 500;
+      res.end(err.message);
+    }
+  });
+  server.listen(0);
+  await once(server, 'listening');
+  const { port } = server.address();
+  base = `http://localhost:${port}`;
+});
+
+after(() => {
+  server.close();
+});
+
+test('GET /login contains Sign in and Google link', async () => {
+  const res = await fetch(`${base}/login`);
+  assert.equal(res.status, 200);
+  const html = await res.text();
+  assert.match(html, /Sign in/);
+  assert.match(html, /Continue with Google/);
+  assert.ok(
+    html.includes('href="/api/auth/login?connection=google-oauth2"'),
+    'Google link href matches'
+  );
+});
+
+for (const page of ['privacy', 'terms', 'cookie-policy']) {
+  test(`GET /legal/${page}.html returns 200`, async () => {
+    const res = await fetch(`${base}/legal/${page}.html`);
+    assert.equal(res.status, 200);
+  });
+}


### PR DESCRIPTION
## Summary
- add `undici` dev dependency for HTTP testing
- add node:test suite to ensure /login shows Google auth link and legal pages return 200

## Testing
- `npm test`


