### PR TITLE
Add Auth0 handler to API

### DIFF
--- a/api/auth/[...auth0].js
+++ b/api/auth/[...auth0].js
@@ -1,0 +1,3 @@
+const { handleAuth } = require('@auth0/nextjs-auth0');
+
+module.exports = handleAuth();


### PR DESCRIPTION
## Summary
- add Auth0 handler route for Next.js authentication

## Testing
- `npm test`
- `npx vercel deploy --prod` *(fails: login required)*

