### PR TITLE
fix: correct Auth0 callback path

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Create a `.env` file with the following variables.
 
 In your Auth0 Single Page Application settings, configure:
 
-- **Allowed Callback URLs**: `https://ai-news-hub-eta.vercel.app/callback.html`
+- **Allowed Callback URLs**: `https://ai-news-hub-eta.vercel.app/auth/callback.html`
 - **Allowed Logout URLs**: `https://ai-news-hub-eta.vercel.app/`
 - **Allowed Web Origins**: `https://ai-news-hub-eta.vercel.app`
 - **(Optional) Application Login URI**: `https://ai-news-hub-eta.vercel.app/`

--- a/public/auth/auth.js
+++ b/public/auth/auth.js
@@ -2,7 +2,7 @@
   const domain = 'dev-zi3ojkfg51ob4f3c.eu.auth0.com';
   const meta = document.querySelector('meta[name="auth0-client-id"]');
   const clientId = meta ? meta.content : '';
-  const redirect_uri = 'https://ai-news-hub-eta.vercel.app/callback.html';
+  const redirect_uri = 'https://ai-news-hub-eta.vercel.app/auth/callback.html';
   let auth0Client;
   const ready = (async () => {
     try {


### PR DESCRIPTION
## Summary
- point SPA `redirect_uri` to `/auth/callback.html`
- document updated Auth0 callback URL

## Testing
- `npm test`

