### PR TITLE
feat(auth): enable refresh token persistence

### DIFF
--- a/public/auth/auth.js
+++ b/public/auth/auth.js
@@ -42,7 +42,10 @@
       auth0Client = await createClientFn({
         domain,
         clientId,
-        authorizationParams: { redirect_uri }
+        authorizationParams: { redirect_uri },
+        cacheLocation: 'localstorage',
+        useRefreshTokens: true,
+        useRefreshTokensFallback: true
       });
     } catch (e) {
       console.error('Auth0 init failed', e);


### PR DESCRIPTION
## Summary
- configure Auth0 client to cache tokens in local storage and use refresh tokens for renewal

## Testing
- `npm test`


