### PR TITLE
refactor auth initialization with shared promise

### DIFF
--- a/public/auth/auth.js
+++ b/public/auth/auth.js
@@ -1,15 +1,9 @@
-(async () => {
-  const domainMeta = document.querySelector('meta[name="auth0-domain"]');
-  const domain = domainMeta ? domainMeta.content : (window.AUTH0_DOMAIN || '');
-  const clientMeta = document.querySelector('meta[name="auth0-client-id"]');
-  const clientId = clientMeta ? clientMeta.content : (window.AUTH0_CLIENT_ID || '');
-  const redirect_uri = window.location.origin + '/auth/callback.html';
+(() => {
   let auth0Client;
-  const signInBtn = document.getElementById('sign-in-btn');
-  const signOutBtn = document.getElementById('sign-out-btn');
-  if (signInBtn) signInBtn.disabled = true;
-
   let authErrorShown = false;
+  let signInBtn;
+  let signOutBtn;
+
   function showAuthError() {
     if (authErrorShown) return;
     authErrorShown = true;
@@ -28,35 +22,6 @@
     }
   }
 
-  const ready = (async () => {
-    try {
-      const createClientFn =
-        typeof createAuth0Client === 'function'
-          ? createAuth0Client
-          : (window.auth0 && typeof window.auth0.createAuth0Client === 'function'
-              ? window.auth0.createAuth0Client
-              : null);
-      if (!createClientFn) {
-        throw new Error('Auth0 SPA SDK not loaded');
-      }
-      auth0Client = await createClientFn({
-        domain,
-        clientId,
-        authorizationParams: { redirect_uri },
-        cacheLocation: 'localstorage',
-        useRefreshTokens: true,
-        useRefreshTokensFallback: true
-      });
-    } catch (e) {
-      console.error('Auth0 init failed', e);
-    }
-    if (!auth0Client) {
-      showAuthError();
-    } else if (signInBtn) {
-      signInBtn.disabled = false;
-    }
-  })();
-
   async function handleRedirectCallbackSafe() {
     try {
       return await auth0Client.handleRedirectCallback();
@@ -67,7 +32,7 @@
   }
 
   async function withClient(fn, fallback) {
-    await ready;
+    await window.authReady;
     if (!auth0Client) {
       showAuthError();
       return typeof fallback === 'function' ? fallback() : fallback;
@@ -75,18 +40,60 @@
     return fn();
   }
 
-  window.auth = {
-    login: () => withClient(() => auth0Client.loginWithRedirect()),
-    logout: () =>
-      withClient(() =>
-        auth0Client.logout({
-          logoutParams: { returnTo: window.location.origin + '/' }
-        })
-      ),
-    getUser: () => withClient(() => auth0Client.getUser(), null),
-    isAuthenticated: () => withClient(() => auth0Client.isAuthenticated(), false),
-    getIdTokenClaims: () => withClient(() => auth0Client.getIdTokenClaims(), null),
-    handleRedirectCallback: () => withClient(() => handleRedirectCallbackSafe()),
-    ready
+  window.initAuth = function initAuth() {
+    if (window.authReady) return window.authReady;
+    const domainMeta = document.querySelector('meta[name="auth0-domain"]');
+    const domain = domainMeta ? domainMeta.content : (window.AUTH0_DOMAIN || '');
+    const clientMeta = document.querySelector('meta[name="auth0-client-id"]');
+    const clientId = clientMeta ? clientMeta.content : (window.AUTH0_CLIENT_ID || '');
+    const redirect_uri = window.location.origin + '/auth/callback.html';
+    signInBtn = document.getElementById('sign-in-btn');
+    signOutBtn = document.getElementById('sign-out-btn');
+    if (signInBtn) signInBtn.disabled = true;
+
+    window.authReady = (async () => {
+      try {
+        const createClientFn =
+          typeof createAuth0Client === 'function'
+            ? createAuth0Client
+            : (window.auth0 && typeof window.auth0.createAuth0Client === 'function'
+                ? window.auth0.createAuth0Client
+                : null);
+        if (!createClientFn) {
+          throw new Error('Auth0 SPA SDK not loaded');
+        }
+        auth0Client = await createClientFn({
+          domain,
+          clientId,
+          authorizationParams: { redirect_uri },
+          cacheLocation: 'localstorage',
+          useRefreshTokens: true,
+          useRefreshTokensFallback: true
+        });
+      } catch (e) {
+        console.error('Auth0 init failed', e);
+      }
+      if (!auth0Client) {
+        showAuthError();
+      } else if (signInBtn) {
+        signInBtn.disabled = false;
+      }
+    })();
+
+    window.auth = {
+      login: () => withClient(() => auth0Client.loginWithRedirect()),
+      logout: () =>
+        withClient(() =>
+          auth0Client.logout({
+            logoutParams: { returnTo: window.location.origin + '/' }
+          })
+        ),
+      getUser: () => withClient(() => auth0Client.getUser(), null),
+      isAuthenticated: () => withClient(() => auth0Client.isAuthenticated(), false),
+      getIdTokenClaims: () => withClient(() => auth0Client.getIdTokenClaims(), null),
+      handleRedirectCallback: () => withClient(() => handleRedirectCallbackSafe())
+    };
+
+    return window.authReady;
   };
 })();

--- a/public/auth/callback.html
+++ b/public/auth/callback.html
@@ -12,7 +12,8 @@
 <body>
   <script>
     window.addEventListener('DOMContentLoaded', async () => {
-      await auth.ready;
+      initAuth();
+      await window.authReady;
       try {
         await auth.handleRedirectCallback();
         window.location.replace(sessionStorage.getItem('postLoginRedirect') || '/');

--- a/public/index.html
+++ b/public/index.html
@@ -461,7 +461,8 @@
   </script>
   <script>
     window.addEventListener('DOMContentLoaded', async () => {
-      await auth.ready;
+      initAuth();
+      await window.authReady;
       const signInBtn = document.getElementById('sign-in-btn');
       const signOutBtn = document.getElementById('sign-out-btn');
       const userName = document.getElementById('user-name');

--- a/public/login/index.html
+++ b/public/login/index.html
@@ -13,7 +13,8 @@
   <p>Redirecting…</p>
   <script>
     window.addEventListener('DOMContentLoaded', async () => {
-      await auth.ready;
+      initAuth();
+      await window.authReady;
       sessionStorage.setItem('postLoginRedirect', '/');
       auth.login();
     });

--- a/public/post.html
+++ b/public/post.html
@@ -98,7 +98,8 @@
         const p = await res.json();
         const date = new Date(p.published_at || Date.now()).toLocaleDateString();
 
-        await auth.ready;
+        initAuth();
+        await window.authReady;
         let authHtml = '';
         if (await auth.isAuthenticated()) {
           currentUser = await auth.getUser();

--- a/public/profile.html
+++ b/public/profile.html
@@ -15,7 +15,8 @@
   <pre id="json" class="bg-slate-100 dark:bg-slate-800 p-4 rounded overflow-auto"></pre>
   <script>
     window.addEventListener('DOMContentLoaded', async () => {
-      await auth.ready;
+      initAuth();
+      await window.authReady;
       if (!(await auth.isAuthenticated())) {
         location.replace('/');
         return;

--- a/public/signup/index.html
+++ b/public/signup/index.html
@@ -13,7 +13,8 @@
   <p>Redirecting…</p>
   <script>
     window.addEventListener('DOMContentLoaded', async () => {
-      await auth.ready;
+      initAuth();
+      await window.authReady;
       sessionStorage.setItem('postLoginRedirect', '/');
       auth.login();
     });


### PR DESCRIPTION
## Summary
- refactor auth code to expose a singleton `initAuth()` and share readiness via `window.authReady`
- ensure pages initialize auth and await `window.authReady` before accessing user state
- update login/signup/callback flows to use new init routine

## Testing
- `npm test`

