### PR TITLE
Use dedicated login page flow

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -120,7 +120,7 @@
 
           <div id="auth-area" class="flex items-center gap-2">
             <span id="user-name" class="font-medium hidden"></span>
-            <button id="sign-in-btn" onclick="(sessionStorage.setItem('postLoginRedirect', location.pathname+location.search), auth.login())" class="hidden px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Sign in</button>
+            <a id="sign-in-btn" href="/login/" class="hidden px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Sign in</a>
             <button id="sign-out-btn" onclick="auth.logout()" class="hidden px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Sign out</button>
             <a id="dashboard-link" href="/profile.html" class="hidden px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Dashboard</a>
           </div>

--- a/public/login/index.html
+++ b/public/login/index.html
@@ -8,15 +8,25 @@
   <meta name="auth0-domain" content="dev-zi3ojkfg51ob4f3c.eu.auth0.com"><!-- Auth0 Domain injected at build time -->
   <script src="https://cdn.auth0.com/js/auth0-spa-js/2.1/auth0-spa-js.production.js" defer></script>
   <script src="/auth/auth.js" defer></script>
+  <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body>
-  <p>Redirecting…</p>
+<body class="min-h-screen flex items-center justify-center">
+  <button id="auth-login-btn" class="px-6 py-3 bg-cyan-500 text-white rounded-lg hover:bg-cyan-600">Continue with Auth0/Google</button>
   <script>
     window.addEventListener('DOMContentLoaded', async () => {
       initAuth();
       await window.authReady;
-      sessionStorage.setItem('postLoginRedirect', '/');
-      auth.login();
+      document.getElementById('auth-login-btn').addEventListener('click', () => {
+        let redirect = '/';
+        try {
+          const ref = document.referrer ? new URL(document.referrer) : null;
+          if (ref && ref.origin === window.location.origin) {
+            redirect = ref.pathname + ref.search;
+          }
+        } catch (e) {}
+        sessionStorage.setItem('postLoginRedirect', redirect);
+        auth.login();
+      });
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- Route home page Sign in button to `/login/` instead of invoking Auth0 directly
- Add visible login button that stores `postLoginRedirect` before calling `auth.login`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e4cd883648328a3d955b2d397ea69