### PR TITLE
Improve auth callback redirect handling

### DIFF
--- a/public/auth/callback.html
+++ b/public/auth/callback.html
@@ -15,10 +15,24 @@
       initAuth();
       await window.authReady;
       try {
-        await auth.handleRedirectCallback();
-        window.location.replace(sessionStorage.getItem('postLoginRedirect') || '/');
+        if (!window.__handledAuthRedirect) {
+          window.__handledAuthRedirect = true;
+          await auth.handleRedirectCallback();
+          const url = new URL(window.location.href);
+          url.searchParams.delete('code');
+          url.searchParams.delete('state');
+          window.history.replaceState({}, document.title, url.pathname + url.search + url.hash);
+        }
+
+        const redirectPath = sessionStorage.getItem('postLoginRedirect');
+        if (redirectPath) {
+          sessionStorage.removeItem('postLoginRedirect');
+          window.location.replace(redirectPath);
+        } else {
+          window.location.replace('/');
+        }
       } catch (e) {
-        // auth.handleRedirectCallback already renders an error message
+        document.body.innerHTML = `<p>Authentication failed.</p><p><a href="/">Back to home</a></p>`;
       }
     });
   </script>


### PR DESCRIPTION
## Summary
- Ensure Auth0 redirect callback executes only once, strip `code`/`state` params, and redirect to stored path or home
- Show friendly error with link back home when callback processing fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e4e5823348328bd27db19541d1066