### PR TITLE
feat: update auth UI dynamically

### DIFF
--- a/public/auth/auth.js
+++ b/public/auth/auth.js
@@ -3,6 +3,27 @@
   let authErrorShown = false;
   let signInBtn;
   let signOutBtn;
+  
+  async function updateAuthUI() {
+    if (!window.auth) return;
+    const userNameEl = document.getElementById('user-name');
+    const profileLink = document.getElementById('profile-link') || document.getElementById('dashboard-link');
+    if (await window.auth.isAuthenticated()) {
+      const user = await window.auth.getUser();
+      if (userNameEl && user) {
+        userNameEl.textContent = user.name || user.email || '';
+        userNameEl.classList.remove('hidden');
+      }
+      if (signInBtn) signInBtn.classList.add('hidden');
+      if (signOutBtn) signOutBtn.classList.remove('hidden');
+      if (profileLink) profileLink.classList.remove('hidden');
+    } else {
+      if (userNameEl) userNameEl.classList.add('hidden');
+      if (signInBtn) signInBtn.classList.remove('hidden');
+      if (signOutBtn) signOutBtn.classList.add('hidden');
+      if (profileLink) profileLink.classList.add('hidden');
+    }
+  }
 
   function showAuthError() {
     if (authErrorShown) return;
@@ -93,6 +114,8 @@
       getIdTokenClaims: () => withClient(() => auth0Client.getIdTokenClaims(), null),
       handleRedirectCallback: () => withClient(() => handleRedirectCallbackSafe())
     };
+
+    window.updateAuthUI = updateAuthUI;
 
     return window.authReady;
   };

--- a/public/index.html
+++ b/public/index.html
@@ -122,7 +122,7 @@
             <span id="user-name" class="font-medium hidden"></span>
             <button id="sign-in-btn" onclick="(sessionStorage.setItem('postLoginRedirect', location.pathname+location.search), auth.login())" class="hidden px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Sign in</button>
             <button id="sign-out-btn" onclick="auth.logout()" class="hidden px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Sign out</button>
-            <a id="dashboard-link" href="/profile.html" class="hidden px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Dashboard</a>
+            <a id="profile-link" href="/profile.html" class="hidden px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Profile</a>
           </div>
 
           <button id="theme-toggle" class="w-10 h-10 rounded-full bg-slate-100 dark:bg-slate-800 flex items-center justify-center hover:bg-slate-200 dark:hover:bg-slate-700">
@@ -463,23 +463,10 @@
     window.addEventListener('DOMContentLoaded', async () => {
       initAuth();
       await window.authReady;
-      const signInBtn = document.getElementById('sign-in-btn');
-      const signOutBtn = document.getElementById('sign-out-btn');
-      const userName = document.getElementById('user-name');
-      const dashboardLink = document.getElementById('dashboard-link');
-      if (await auth.isAuthenticated()) {
-        const user = await auth.getUser();
-        userName.textContent = user.name || user.email;
-        userName.classList.remove('hidden');
-        signInBtn.classList.add('hidden');
-        signOutBtn.classList.remove('hidden');
-        if (dashboardLink) dashboardLink.classList.remove('hidden');
-      } else {
-        userName.classList.add('hidden');
-        signInBtn.classList.remove('hidden');
-        signOutBtn.classList.add('hidden');
-        if (dashboardLink) dashboardLink.classList.add('hidden');
-      }
+      updateAuthUI();
+      document.addEventListener('visibilitychange', () => {
+        if (!document.hidden) updateAuthUI();
+      });
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add `updateAuthUI` helper to toggle auth controls and display user info
- call `updateAuthUI` after `authReady` and when tab visibility changes
- rename dashboard link to profile link

## Testing
- `npm test`

