### PR TITLE
feat: hide profile sub behind collapsible section

### DIFF
--- a/public/profile.html
+++ b/public/profile.html
@@ -27,9 +27,12 @@
         <i id="verified" class="fa-solid fa-circle-check text-green-500 hidden" title="Verified"></i>
       </h2>
       <p id="email" class="text-slate-600 dark:text-slate-300"></p>
-      <p id="sub" class="text-sm text-slate-500 break-all"></p>
     </div>
   </div>
+  <details class="mt-4">
+    <summary class="cursor-pointer text-blue-600 hover:underline">Account details</summary>
+    <p id="sub" class="mt-2 text-sm text-slate-500 break-all"></p>
+  </details>
   <button id="logout-btn" class="mt-4 px-4 py-2 bg-red-500 text-white rounded hover:bg-red-600">Sign out</button>
   <script>
     const htmlEl = document.documentElement;


### PR DESCRIPTION
## Summary
- hide `sub` in profile behind collapsible "Account details" details section

## Testing
- `npm test`


