### PR TITLE
Use profile page as post-login redirect

### DIFF
--- a/public/auth/callback.html
+++ b/public/auth/callback.html
@@ -29,7 +29,7 @@
           sessionStorage.removeItem('postLoginRedirect');
           window.location.replace(redirectPath);
         } else {
-          window.location.replace('/');
+          window.location.replace('/profile.html');
         }
       } catch (e) {
         document.body.innerHTML = `<p>Authentication failed.</p><p><a href="/">Back to home</a></p>`;

--- a/public/login/index.html
+++ b/public/login/index.html
@@ -15,7 +15,7 @@
     window.addEventListener('DOMContentLoaded', async () => {
       initAuth();
       await window.authReady;
-      sessionStorage.setItem('postLoginRedirect', '/');
+      sessionStorage.setItem('postLoginRedirect', '/profile.html');
       auth.login();
     });
   </script>


### PR DESCRIPTION
## Summary
- Default login page sets post-login redirect to profile page
- Auth callback falls back to profile page when no redirect stored

## Testing
- `npm test`