### PR TITLE
feat: secure API with Auth0 audience

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,4 +14,5 @@ AUTH0_ISSUER_BASE_URL=https://your-tenant.auth0.com
 # Auth0 application credentials (use the production app's values in production)
 AUTH0_CLIENT_ID=your-auth0-client-id
 AUTH0_CLIENT_SECRET=your-auth0-client-secret
+AUTH0_AUDIENCE=https://ai-news-hub.api
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Create a `.env` file with the following variables.
 
 - `DATABASE_URL` – Postgres connection string (Neon requires SSL)
 
+### Auth0
+
+- `AUTH0_AUDIENCE` – `https://ai-news-hub.api`
+
 ## Auth0 Dashboard Settings
 
 In your Auth0 Single Page Application settings, configure:
@@ -18,6 +22,8 @@ In your Auth0 Single Page Application settings, configure:
 - **(Optional) Application Login URI**: `https://ai-news-hub-eta.vercel.app/`
 
 Enable Google and Username-Password-Authentication connections.
+
+We secure `/api` routes with Auth0 JWTs (audience: `https://ai-news-hub.api`). Mutating routes require `posts:write` or `admin:all`.
 
 ## Database Setup (Neon)
 

--- a/api/lib/auth.js
+++ b/api/lib/auth.js
@@ -1,1 +1,68 @@
-module.exports = require('../../lib/auth');
+const jwt = require('jsonwebtoken');
+const jwksRsa = require('jwks-rsa');
+const { ensureConfig } = require('../../lib/auth');
+
+let client;
+function getClient() {
+  if (!client) {
+    ensureConfig(['AUTH0_ISSUER_BASE_URL', 'AUTH0_AUDIENCE']);
+    client = jwksRsa({
+      jwksUri: `${process.env.AUTH0_ISSUER_BASE_URL}/.well-known/jwks.json`,
+      cache: true,
+      rateLimit: true
+    });
+  }
+  return client;
+}
+
+function getKey(header, callback) {
+  getClient().getSigningKey(header.kid, (err, key) => {
+    if (err) return callback(err);
+    const signingKey = key.getPublicKey ? key.getPublicKey() : key.publicKey || key.rsaPublicKey;
+    callback(null, signingKey);
+  });
+}
+
+async function requireAuth(req, res) {
+  const authHeader = req.headers && req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    res.status(401).json({ error: 'unauthorized' });
+    return null;
+  }
+  const token = authHeader.slice(7);
+  try {
+    const decoded = await new Promise((resolve, reject) => {
+      jwt.verify(
+        token,
+        getKey,
+        {
+          audience: process.env.AUTH0_AUDIENCE,
+          issuer: `${process.env.AUTH0_ISSUER_BASE_URL}/`,
+          algorithms: ['RS256']
+        },
+        (err, decoded) => {
+          if (err) return reject(err);
+          resolve(decoded);
+        }
+      );
+    });
+    req.auth = decoded;
+    return decoded;
+  } catch (err) {
+    res.status(401).json({ error: 'invalid_token' });
+    return null;
+  }
+}
+
+function requirePermission(perm) {
+  return (req, res) => {
+    const perms = req.auth?.permissions || (req.auth?.scope ? req.auth.scope.split(' ') : []);
+    if (perms.includes('admin:all') || perms.includes(perm)) {
+      return true;
+    }
+    res.status(403).json({ error: 'forbidden' });
+    return false;
+  };
+}
+
+module.exports = { requireAuth, requirePermission };

--- a/api/posts/[id].js
+++ b/api/posts/[id].js
@@ -1,13 +1,11 @@
 const db = require('../../lib/db');
-const requireAdmin = require('../../lib/requireAdmin');
-const { ensureCsrf, validateCsrf } = require('../../lib/csrf');
 const { ensureConfig } = require('../../lib/auth');
+const { requireAuth, requirePermission } = require('../lib/auth');
 
 module.exports = async (req, res) => {
   const id = req.query.id;
   try {
     ensureConfig();
-    ensureCsrf(req, res);
     if (req.method === 'GET') {
       const isNumeric = /^\d+$/.test(id);
       const query = isNumeric
@@ -18,11 +16,9 @@ module.exports = async (req, res) => {
       return res.status(200).json(rows[0]);
     }
     if (req.method === 'PUT') {
-      const admin = await requireAdmin(req, res);
-      if (!admin) return;
-      if (!validateCsrf(req)) {
-        return res.status(403).json({ error: 'invalid_csrf_token' });
-      }
+      const auth = await requireAuth(req, res);
+      if (!auth) return;
+      if (!requirePermission('posts:write')(req, res)) return;
 
       let body;
       try {
@@ -41,11 +37,9 @@ module.exports = async (req, res) => {
       return res.status(200).json(rows[0]);
     }
     if (req.method === 'DELETE') {
-      const admin = await requireAdmin(req, res);
-      if (!admin) return;
-      if (!validateCsrf(req)) {
-        return res.status(403).json({ error: 'invalid_csrf_token' });
-      }
+      const auth = await requireAuth(req, res);
+      if (!auth) return;
+      if (!requirePermission('posts:write')(req, res)) return;
 
       const isNumeric = /^\d+$/.test(id);
       const query = isNumeric

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -4,7 +4,8 @@ const REQUIRED_KEYS = [
   'AUTH0_BASE_URL',
   'AUTH0_ISSUER_BASE_URL',
   'AUTH0_CLIENT_ID',
-  'AUTH0_CLIENT_SECRET'
+  'AUTH0_CLIENT_SECRET',
+  'AUTH0_AUDIENCE'
 ];
 
 class ConfigError extends Error {

--- a/public/auth/callback.html
+++ b/public/auth/callback.html
@@ -6,6 +6,7 @@
   <title>Auth Callback</title>
   <meta name="auth0-client-id" content="a2MdQnWFC2HOqBY09V4EZ7KOFjj3fXNK"><!-- Auth0 Client ID injected at build time -->
   <meta name="auth0-domain" content="dev-zi3ojkfg51ob4f3c.eu.auth0.com"><!-- Auth0 Domain injected at build time -->
+  <meta name="auth0-audience" content="__INJECTED__" />
   <script src="https://cdn.auth0.com/js/auth0-spa-js/2.1/auth0-spa-js.production.js"></script>
   <script src="/auth/auth.js"></script>
 </head>

--- a/public/index.html
+++ b/public/index.html
@@ -9,8 +9,10 @@
 
   <meta name="auth0-client-id" content="a2MdQnWFC2HOqBY09V4EZ7KOFjj3fXNK"><!-- Auth0 Client ID injected at build time -->
   <meta name="auth0-domain" content="dev-zi3ojkfg51ob4f3c.eu.auth0.com"><!-- Auth0 Domain injected at build time -->
+  <meta name="auth0-audience" content="__INJECTED__" />
   <script src="https://cdn.auth0.com/js/auth0-spa-js/2.1/auth0-spa-js.production.js" defer></script>
   <script src="/auth/auth.js" defer></script>
+  <script src="/resources/roles.js" defer></script>
 
   <!-- Open Graph -->
   <meta property="og:title" content="AI News Hub" />
@@ -124,6 +126,7 @@
               <img id="profile-avatar" class="w-6 h-6 rounded-full mr-2 hidden" alt="Profile avatar" />
               Profile
             </a>
+            <a id="admin-link" href="/admin.html" class="hidden px-4 py-4 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Admin</a>
           </div>
 
           <button id="theme-toggle" class="w-11 h-11 rounded-full bg-slate-100 dark:bg-slate-800 flex items-center justify-center hover:bg-slate-200 dark:hover:bg-slate-700" aria-label="Toggle theme">
@@ -146,6 +149,7 @@
       <a href="#chatgpt" class="block px-4 py-4 rounded hover:bg-slate-100 dark:hover:bg-slate-800">ChatGPT Updates</a>
       <a href="#industry" class="block px-4 py-4 rounded hover:bg-slate-100 dark:hover:bg-slate-800">AI Industry</a>
       <a href="#research" class="block px-4 py-4 rounded hover:bg-slate-100 dark:hover:bg-slate-800">Research &amp; Innovation</a>
+      <a id="admin-link-mobile" href="/admin.html" class="hidden block px-4 py-4 rounded hover:bg-slate-100 dark:hover:bg-slate-800">Admin</a>
     </div>
   </nav>
   <div id="menu-backdrop" class="fixed inset-0 bg-black/50 z-40 hidden"></div>
@@ -472,17 +476,15 @@
     document.addEventListener('DOMContentLoaded', loadAll);
   </script>
   <script>
-  window.addEventListener('DOMContentLoaded', async () => {
-    initAuth();
-    await window.authReady;
-    updateAuthUI();
-    document.addEventListener('visibilitychange', () => {
-      if (!document.hidden) updateAuthUI();
-    });
-  });
-</script>
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
+    window.addEventListener('DOMContentLoaded', async () => {
+      initAuth();
+      await window.authReady;
+      if (typeof initRoles === 'function') await initRoles();
+      updateAuthUI();
+      document.addEventListener('visibilitychange', () => {
+        if (!document.hidden) updateAuthUI();
+      });
+
       const menu = document.getElementById('mobile-menu');
       const backdrop = document.getElementById('menu-backdrop');
       const btn = document.getElementById('menu-button');
@@ -538,21 +540,17 @@
         if (e.key === 'Escape') closeMenu();
       });
 
-      if (window.authReady) {
-        window.authReady.then(async () => {
-          if (await auth.isAuthenticated()) {
-            let link = document.getElementById('profile-link-mobile');
-            if (!link) {
-              const menuLinks = document.getElementById('mobile-menu-links');
-              link = document.createElement('a');
-              link.id = 'profile-link-mobile';
-              link.href = '/profile.html';
-              link.className = 'block px-4 py-4 rounded hover:bg-slate-100 dark:hover:bg-slate-800';
-              link.textContent = 'Profile';
-              menuLinks.appendChild(link);
-            }
-          }
-        });
+      if (await auth.isAuthenticated()) {
+        let link = document.getElementById('profile-link-mobile');
+        if (!link) {
+          const menuLinks = document.getElementById('mobile-menu-links');
+          link = document.createElement('a');
+          link.id = 'profile-link-mobile';
+          link.href = '/profile.html';
+          link.className = 'block px-4 py-4 rounded hover:bg-slate-100 dark:hover:bg-slate-800';
+          link.textContent = 'Profile';
+          menuLinks.appendChild(link);
+        }
       }
     });
   </script>

--- a/public/login/index.html
+++ b/public/login/index.html
@@ -6,6 +6,7 @@
   <title>Sign in</title>
   <meta name="auth0-client-id" content="a2MdQnWFC2HOqBY09V4EZ7KOFjj3fXNK"><!-- Auth0 Client ID injected at build time -->
   <meta name="auth0-domain" content="dev-zi3ojkfg51ob4f3c.eu.auth0.com"><!-- Auth0 Domain injected at build time -->
+  <meta name="auth0-audience" content="__INJECTED__" />
   <script src="https://cdn.auth0.com/js/auth0-spa-js/2.1/auth0-spa-js.production.js" defer></script>
   <script src="/auth/auth.js" defer></script>
 </head>

--- a/public/post.html
+++ b/public/post.html
@@ -8,8 +8,10 @@
   <link rel="canonical" href="/post.html" />
   <meta name="auth0-client-id" content="a2MdQnWFC2HOqBY09V4EZ7KOFjj3fXNK"><!-- Auth0 Client ID injected at build time -->
   <meta name="auth0-domain" content="dev-zi3ojkfg51ob4f3c.eu.auth0.com"><!-- Auth0 Domain injected at build time -->
+  <meta name="auth0-audience" content="__INJECTED__" />
   <script src="https://cdn.auth0.com/js/auth0-spa-js/2.1/auth0-spa-js.production.js" defer></script>
   <script src="/auth/auth.js" defer></script>
+  <script src="/resources/roles.js" defer></script>
   <!-- Tailwind & Icons -->
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
@@ -28,17 +30,6 @@
     let currentUser = null;
     let currentPostId = null;
 
-    function getCsrfToken() {
-      const match = document.cookie.split('; ').find(c => c.startsWith('csrf='));
-      return match ? match.split('=')[1].split('.')[0] : '';
-    }
-
-    function csrfFetch(url, options = {}) {
-      const headers = options.headers || {};
-      headers['X-CSRF-Token'] = getCsrfToken();
-      return fetch(url, { ...options, headers, credentials: 'include' });
-    }
-
     async function loadComments(postId) {
       try {
         const res = await fetch(`/api/comments?post_id=${postId}`);
@@ -50,7 +41,7 @@
               <div class="border-b pb-2">
                 <div class="flex items-center justify-between mb-1">
                   <div class="text-sm text-slate-500">${c.name || 'Anonymous'} &bull; ${new Date(c.created_at).toLocaleString()}</div>
-                  ${currentUser && (currentUser.role === 'admin' || currentUser.id === c.user_id)
+                  ${currentUser && (currentUser.sub === c.user_id || window.isAdmin)
                     ? `<button data-id="${c.id}" class="comment-delete text-xs text-red-500 hover:underline">Delete</button>`
                     : ''}
                 </div>
@@ -70,9 +61,13 @@
         const textarea = document.getElementById('comment-content');
         const content = textarea.value.trim();
         if (!content) return;
-        const res = await csrfFetch('/api/comments', {
+        const token = await getApiToken();
+        const res = await fetch('/api/comments', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${token}`
+          },
           body: JSON.stringify({ post_id: postId, content })
         });
         if (res.ok) {
@@ -100,6 +95,7 @@
 
         initAuth();
         await window.authReady;
+        if (typeof initRoles === 'function') await initRoles();
         let authHtml = '';
         if (await auth.isAuthenticated()) {
           currentUser = await auth.getUser();
@@ -130,7 +126,11 @@
           const btn = e.target.closest('.comment-delete');
           if (btn) {
             const id = btn.dataset.id;
-            const res = await csrfFetch(`/api/comments/${id}`, { method: 'DELETE' });
+            const token = await getApiToken();
+            const res = await fetch(`/api/comments/${id}`, {
+              method: 'DELETE',
+              headers: { 'Authorization': `Bearer ${token}` }
+            });
             if (res.ok) {
               loadComments(currentPostId);
             } else {

--- a/public/profile.html
+++ b/public/profile.html
@@ -6,6 +6,7 @@
   <title>Your Profile</title>
   <meta name="auth0-client-id" content="a2MdQnWFC2HOqBY09V4EZ7KOFjj3fXNK"><!-- Auth0 Client ID injected at build time -->
   <meta name="auth0-domain" content="dev-zi3ojkfg51ob4f3c.eu.auth0.com"><!-- Auth0 Domain injected at build time -->
+  <meta name="auth0-audience" content="__INJECTED__" />
   <script src="https://cdn.auth0.com/js/auth0-spa-js/2.1/auth0-spa-js.production.js" defer></script>
   <script src="/auth/auth.js" defer></script>
   <script src="https://cdn.tailwindcss.com"></script>
@@ -21,7 +22,7 @@
   </div>
   <div id="profile-card" class="max-w-xl mx-auto bg-slate-100 dark:bg-slate-800 p-6 rounded shadow-md flex items-center gap-4">
     <img id="avatar" class="w-20 h-20 rounded-full object-cover" src="" alt="Profile picture">
-    <div id="avatar-placeholder" class="w-20 h-20 rounded-full bg-slate-400 flex items-center justify-center text-2xl font-semibold text-white hidden"></div>
+    <div id="avatar-placeholder" class="w-20 h-20 rounded-full bg-slate-400 dark:bg-slate-600 flex items-center justify-center text-2xl font-semibold text-white hidden"></div>
     <div>
       <h2 class="text-xl font-semibold flex items-center gap-2">
         <span id="name"></span>

--- a/public/resources/roles.js
+++ b/public/resources/roles.js
@@ -1,0 +1,35 @@
+(() => {
+  function parseJwt(token) {
+    try {
+      const base64Url = token.split('.')[1];
+      const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+      const jsonPayload = decodeURIComponent(
+        atob(base64).split('').map(c => `%${('00' + c.charCodeAt(0).toString(16)).slice(-2)}`).join('')
+      );
+      return JSON.parse(jsonPayload);
+    } catch (e) {
+      return {};
+    }
+  }
+
+  window.parseJwt = parseJwt;
+
+  window.initRoles = async function initRoles() {
+    try {
+      const token = await getApiToken();
+      const { permissions = [] } = parseJwt(token);
+      const isAdmin = permissions.includes('admin:all');
+      window.isAdmin = isAdmin;
+      const adminLink = document.getElementById('admin-link');
+      const adminLinkMobile = document.getElementById('admin-link-mobile');
+      if (adminLink) adminLink.classList.toggle('hidden', !isAdmin);
+      if (adminLinkMobile) adminLinkMobile.classList.toggle('hidden', !isAdmin);
+    } catch (e) {
+      window.isAdmin = false;
+      const adminLink = document.getElementById('admin-link');
+      const adminLinkMobile = document.getElementById('admin-link-mobile');
+      if (adminLink) adminLink.classList.add('hidden');
+      if (adminLinkMobile) adminLinkMobile.classList.add('hidden');
+    }
+  };
+})();

--- a/public/signup/index.html
+++ b/public/signup/index.html
@@ -6,6 +6,7 @@
   <title>Sign up</title>
   <meta name="auth0-client-id" content="a2MdQnWFC2HOqBY09V4EZ7KOFjj3fXNK"><!-- Auth0 Client ID injected at build time -->
   <meta name="auth0-domain" content="dev-zi3ojkfg51ob4f3c.eu.auth0.com"><!-- Auth0 Domain injected at build time -->
+  <meta name="auth0-audience" content="__INJECTED__" />
   <script src="https://cdn.auth0.com/js/auth0-spa-js/2.1/auth0-spa-js.production.js" defer></script>
   <script src="/auth/auth.js" defer></script>
 </head>

--- a/scripts/inject-auth0.js
+++ b/scripts/inject-auth0.js
@@ -4,8 +4,9 @@ const path = require('path');
 
 const clientId = process.env.AUTH0_CLIENT_ID;
 const domain = process.env.AUTH0_DOMAIN;
-if (!clientId || !domain) {
-  console.error('AUTH0_CLIENT_ID or AUTH0_DOMAIN not set');
+const audience = process.env.AUTH0_AUDIENCE;
+if (!clientId || !domain || !audience) {
+  console.error('AUTH0_CLIENT_ID, AUTH0_DOMAIN or AUTH0_AUDIENCE not set');
   process.exit(1);
 }
 
@@ -23,6 +24,7 @@ for (const file of files) {
   const src = fs.readFileSync(filePath, 'utf8');
   const updated = src
     .replace(/\$\{AUTH0_CLIENT_ID\}/g, clientId)
-    .replace(/\$\{AUTH0_DOMAIN\}/g, domain);
+    .replace(/\$\{AUTH0_DOMAIN\}/g, domain)
+    .replace(/__INJECTED__/g, audience);
   fs.writeFileSync(filePath, updated);
 }


### PR DESCRIPTION
## Summary
- expose Auth0 audience to static pages and injector
- verify Auth0 access tokens and permissions for API routes
- add client-side helpers for fetching API tokens and admin gating

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f18fffc648328ae2a7b2b0dc8a362