### PR TITLE
feat: add authenticated fetch helper

### DIFF
--- a/public/resources/api.js
+++ b/public/resources/api.js
@@ -1,0 +1,14 @@
+export async function fetchWithAuth(input, init = {}) {
+  if (!window.__auth) {
+    await new Promise(resolve => {
+      document.addEventListener('auth:ready', resolve, { once: true });
+    });
+  }
+  const token = await window.__auth.getApiToken();
+  const headers = new Headers(init.headers || {});
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+  headers.set('Content-Type', 'application/json');
+  return fetch(input, { ...init, headers });
+}


### PR DESCRIPTION
## Summary
- add fetchWithAuth utility to centralize authorized fetch requests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f264cdf6483289971499124e24211