### PR TITLE
feat: add shared mobile header scripts and styles

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,6 +22,8 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/resources/site.css">
+  <script src="/resources/site.js" defer></script>
 
   <script>
     tailwind.config = {
@@ -70,7 +72,6 @@
     body{font-family:'Inter',sans-serif;background:#f8fafc;color:#0f172a;transition:background-color .3s,color .3s}
     .dark body{background:#0f172a;color:#e2e8f0}
     .gradient-bg{background:linear-gradient(135deg,#0ea5e9,#06b6d4,#818cf8);background-size:200% 200%;animation:text-gradient 8s ease infinite}
-    .sticky-nav{position:sticky;top:0;z-index:50;backdrop-filter:blur(10px);transition:all .3s}
     .post-card{transition:transform .3s,box-shadow .3s;overflow:hidden}
     .post-card:hover{transform:translateY(-4px);box-shadow:0 20px 25px -5px rgb(0 0 0 / .1),0 10px 10px -5px rgb(0 0 0 / .04)}
     .hero-title{font-size:clamp(2rem,5vw,3.5rem);line-height:1.1;text-shadow:0 2px 10px rgb(0 0 0 / .2)}
@@ -95,9 +96,9 @@
   </div>
 
   <!-- Header -->
-  <header class="sticky-nav bg-white/80 dark:bg-dark/80 py-4 border-b border-slate-200 dark:border-slate-800 shadow-sm">
-    <div class="max-w-6xl mx-auto px-4">
-      <div class="flex items-center justify-between">
+  <header class="sticky-nav bg-white/80 dark:bg-dark/80 border-b border-slate-200 dark:border-slate-800 shadow-sm">
+    <div class="max-w-6xl mx-auto px-4 h-full">
+      <div class="flex items-center justify-between h-full">
         <a class="flex items-center" href="#">
           <span class="w-10 h-10 rounded-full bg-gradient-to-r from-primary to-secondary flex items-center justify-center mr-3">
             <i class="fa-solid fa-brain text-white text-lg"></i>
@@ -106,10 +107,10 @@
         </a>
 
         <nav class="hidden md:flex items-center gap-1">
-          <a href="#openai"   class="px-4 py-4 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">OpenAI News</a>
-          <a href="#chatgpt"  class="px-4 py-4 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">ChatGPT Updates</a>
-          <a href="#industry" class="px-4 py-4 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">AI Industry</a>
-          <a href="#research" class="px-4 py-4 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Research & Innovation</a>
+          <a href="#openai"   class="nav-link rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">OpenAI News</a>
+          <a href="#chatgpt"  class="nav-link rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">ChatGPT Updates</a>
+          <a href="#industry" class="nav-link rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">AI Industry</a>
+          <a href="#research" class="nav-link rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Research & Innovation</a>
         </nav>
 
         <div class="flex items-center gap-4">
@@ -120,10 +121,10 @@
           </div>
 
           <div id="auth-area" class="flex items-center gap-2">
-            <button id="sign-in-btn" onclick="(sessionStorage.setItem('postLoginRedirect', location.pathname+location.search), auth.login())" class="hidden px-4 py-4 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Sign in</button>
-            <a id="profile-link" href="/profile.html" class="hidden px-4 py-4 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800 flex items-center">
+            <button id="sign-in-btn" onclick="(sessionStorage.setItem('postLoginRedirect', location.pathname+location.search), auth.login())" class="nav-link hidden rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Sign in</button>
+            <a id="profile-link" href="/profile.html" class="nav-link hidden rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800 flex items-center">
               <img id="profile-avatar" class="w-6 h-6 rounded-full mr-2 hidden" alt="Profile avatar" />
-              Profile
+              <span class="label">Profile</span>
             </a>
           </div>
 
@@ -141,19 +142,20 @@
   </header>
 
   <!-- Mobile Menu -->
-  <nav id="mobile-menu" class="fixed inset-y-0 left-0 w-64 bg-white dark:bg-dark transform -translate-x-full transition-transform z-50">
-    <div id="mobile-menu-links" class="pt-20 px-4 space-y-1">
-      <a href="#openai" class="block px-4 py-4 rounded hover:bg-slate-100 dark:hover:bg-slate-800">OpenAI News</a>
-      <a href="#chatgpt" class="block px-4 py-4 rounded hover:bg-slate-100 dark:hover:bg-slate-800">ChatGPT Updates</a>
-      <a href="#industry" class="block px-4 py-4 rounded hover:bg-slate-100 dark:hover:bg-slate-800">AI Industry</a>
-      <a href="#research" class="block px-4 py-4 rounded hover:bg-slate-100 dark:hover:bg-slate-800">Research &amp; Innovation</a>
-      <a id="profile-link-mobile" href="/profile.html" class="hidden block px-4 py-4 rounded hover:bg-slate-100 dark:hover:bg-slate-800">Profile</a>
+  <nav id="mobile-menu" class="mobile-nav bg-white dark:bg-dark shadow-md" aria-hidden="true">
+    <div id="mobile-menu-links" class="px-4 pt-16 pb-4 space-y-1">
+      <a href="#openai" class="nav-link rounded hover:bg-slate-100 dark:hover:bg-slate-800">OpenAI News</a>
+      <a href="#chatgpt" class="nav-link rounded hover:bg-slate-100 dark:hover:bg-slate-800">ChatGPT Updates</a>
+      <a href="#industry" class="nav-link rounded hover:bg-slate-100 dark:hover:bg-slate-800">AI Industry</a>
+      <a href="#research" class="nav-link rounded hover:bg-slate-100 dark:hover:bg-slate-800">Research &amp; Innovation</a>
+      <a id="profile-link-mobile" href="/profile.html" class="nav-link hidden rounded hover:bg-slate-100 dark:hover:bg-slate-800">Profile</a>
+      <a id="admin-link-mobile" href="/admin.html" class="nav-link hidden rounded hover:bg-slate-100 dark:hover:bg-slate-800">Admin</a>
     </div>
   </nav>
-  <div id="menu-backdrop" class="fixed inset-0 bg-black/50 z-40 hidden"></div>
+  <div id="menu-backdrop" class="mobile-nav-backdrop"></div>
 
   <!-- Hero -->
-  <section class="relative py-16 md:py-24 bg-gradient-to-r from-blue-900 to-indigo-900 dark:from-slate-900 dark:to-slate-900 text-white overflow-hidden">
+  <section class="hero relative py-16 md:py-24 bg-gradient-to-r from-blue-900 to-indigo-900 dark:from-slate-900 dark:to-slate-900 text-white overflow-hidden">
     <div class="absolute inset-0 bg-grid-slate-900/[0.04] dark:bg-grid-slate-400/[0.05]"></div>
     <div class="max-w-6xl mx-auto px-4 relative z-10 text-center">
       <span class="px-4 py-1 bg-white/20 backdrop-blur-sm rounded-full text-sm font-medium inline-block mb-6">Breaking News</span>
@@ -299,17 +301,6 @@
 
   <!-- Scripts -->
   <script>
-    // -------- Theme toggle --------
-    const htmlEl = document.documentElement;
-    const themeToggle = document.getElementById('theme-toggle');
-    const savedTheme = localStorage.getItem('theme');
-    if (savedTheme === 'dark') htmlEl.classList.add('dark');
-
-    themeToggle.addEventListener('click', () => {
-      htmlEl.classList.toggle('dark');
-      localStorage.setItem('theme', htmlEl.classList.contains('dark') ? 'dark' : 'light');
-    });
-
     // -------- Helpers --------
     const byId = id => document.getElementById(id);
     const openaiGrid   = byId('openai-grid');
@@ -478,31 +469,18 @@
       document.addEventListener('auth:ready', () => {
         const isAdmin = document.documentElement.dataset.admin === 'true';
         const authArea = document.getElementById('auth-area');
-        const mobileLinks = document.getElementById('mobile-menu-links');
-
         let adminLink = document.getElementById('admin-link');
         if (isAdmin) {
           if (!adminLink) {
             adminLink = document.createElement('a');
             adminLink.id = 'admin-link';
             adminLink.href = '/admin.html';
-            adminLink.className = 'px-4 py-4 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800';
+            adminLink.className = 'nav-link rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800';
             adminLink.textContent = 'Admin';
             authArea.appendChild(adminLink);
           }
-          let adminLinkMobile = document.getElementById('admin-link-mobile');
-          if (!adminLinkMobile) {
-            adminLinkMobile = document.createElement('a');
-            adminLinkMobile.id = 'admin-link-mobile';
-            adminLinkMobile.href = '/admin.html';
-            adminLinkMobile.className = 'block px-4 py-4 rounded hover:bg-slate-100 dark:hover:bg-slate-800';
-            adminLinkMobile.textContent = 'Admin';
-            mobileLinks.appendChild(adminLinkMobile);
-          }
-        } else {
-          if (adminLink) adminLink.remove();
-          const adminLinkMobile = document.getElementById('admin-link-mobile');
-          if (adminLinkMobile) adminLinkMobile.remove();
+        } else if (adminLink) {
+          adminLink.remove();
         }
       });
 
@@ -511,61 +489,6 @@
       updateAuthUI();
       document.addEventListener('visibilitychange', () => {
         if (!document.hidden) updateAuthUI();
-      });
-
-      const menu = document.getElementById('mobile-menu');
-      const backdrop = document.getElementById('menu-backdrop');
-      const btn = document.getElementById('menu-button');
-
-      let firstFocusable, lastFocusable;
-
-      function trapFocus(e) {
-        if (e.key !== 'Tab') return;
-        if (e.shiftKey) {
-          if (document.activeElement === firstFocusable) {
-            e.preventDefault();
-            lastFocusable.focus();
-          }
-        } else {
-          if (document.activeElement === lastFocusable) {
-            e.preventDefault();
-            firstFocusable.focus();
-          }
-        }
-      }
-
-      function openMenu() {
-        menu.classList.remove('-translate-x-full');
-        backdrop.classList.remove('hidden');
-        document.body.classList.add('overflow-hidden');
-        btn.setAttribute('aria-expanded', 'true');
-
-        const focusable = menu.querySelectorAll('a, button, input, select, textarea, [tabindex]:not([tabindex="-1"])');
-        if (focusable.length) {
-          firstFocusable = focusable[0];
-          lastFocusable = focusable[focusable.length - 1];
-          firstFocusable.focus();
-          document.addEventListener('keydown', trapFocus);
-        }
-      }
-
-      function closeMenu() {
-        menu.classList.add('-translate-x-full');
-        backdrop.classList.add('hidden');
-        document.body.classList.remove('overflow-hidden');
-        btn.setAttribute('aria-expanded', 'false');
-        document.removeEventListener('keydown', trapFocus);
-        btn.focus();
-      }
-
-      btn.addEventListener('click', () => {
-        const expanded = btn.getAttribute('aria-expanded') === 'true';
-        expanded ? closeMenu() : openMenu();
-      });
-
-      backdrop.addEventListener('click', closeMenu);
-      document.addEventListener('keydown', (e) => {
-        if (e.key === 'Escape') closeMenu();
       });
     });
   </script>

--- a/public/profile.html
+++ b/public/profile.html
@@ -11,6 +11,8 @@
   <script src="/auth/auth.js" defer></script>
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="/resources/site.css">
+  <script src="/resources/site.js" defer></script>
 </head>
 <body class="p-6 bg-light dark:bg-dark">
   <div class="flex justify-between items-center mb-4">
@@ -23,8 +25,8 @@
     </div>
   </div>
   <div id="profile-card" class="max-w-xl mx-auto bg-slate-100 dark:bg-slate-800 p-6 rounded shadow-md flex items-center gap-4">
-    <img id="avatar" class="w-20 h-20 rounded-full object-cover" src="" alt="Profile picture">
-    <div id="avatar-placeholder" class="w-20 h-20 rounded-full bg-slate-400 dark:bg-slate-600 flex items-center justify-center text-2xl font-semibold text-white hidden"></div>
+    <img id="avatar" class="hidden sm:block w-20 h-20 rounded-full object-cover" src="" alt="Profile picture">
+    <div id="avatar-placeholder" class="flex sm:hidden w-20 h-20 rounded-full bg-slate-400 dark:bg-slate-600 items-center justify-center text-2xl font-semibold text-white"></div>
     <div>
       <h2 class="text-xl font-semibold flex items-center gap-2">
         <span id="name"></span>
@@ -38,17 +40,6 @@
     <p id="sub" class="mt-2 text-sm text-slate-500 break-all"></p>
   </details>
   <button id="logout-btn" class="mt-4 w-full sm:w-auto px-4 py-2 bg-secondary text-white rounded hover:bg-cyan-500">Sign out</button>
-  <script>
-    const htmlEl = document.documentElement;
-    const themeToggle = document.getElementById('theme-toggle');
-    const savedTheme = localStorage.getItem('theme');
-    if (savedTheme === 'dark') htmlEl.classList.add('dark');
-
-    themeToggle.addEventListener('click', () => {
-      htmlEl.classList.toggle('dark');
-      localStorage.setItem('theme', htmlEl.classList.contains('dark') ? 'dark' : 'light');
-    });
-  </script>
   <script>
     window.addEventListener('DOMContentLoaded', async () => {
       document.addEventListener('auth:ready', () => {
@@ -78,13 +69,13 @@
       const user = await auth.getUser();
       const avatarImg = document.getElementById('avatar');
       const avatarPlaceholder = document.getElementById('avatar-placeholder');
+      const initial = (user.name || user.nickname || '?').charAt(0).toUpperCase();
+      avatarPlaceholder.textContent = initial;
       if (user.picture) {
         avatarImg.src = user.picture;
+        avatarImg.classList.remove('hidden');
       } else {
-        avatarImg.classList.add('hidden');
-        const initial = (user.name || user.nickname || '?').charAt(0).toUpperCase();
-        avatarPlaceholder.textContent = initial;
-        avatarPlaceholder.classList.remove('hidden');
+        avatarPlaceholder.classList.remove('sm:hidden');
       }
       document.getElementById('name').textContent = user.name || user.nickname || '';
       document.getElementById('email').textContent = user.email || '';

--- a/public/resources/site.css
+++ b/public/resources/site.css
@@ -1,0 +1,59 @@
+/* Site-wide mobile header styles and utilities */
+
+/* Sticky top bar with 3.5rem height */
+.sticky-nav {
+  position: sticky;
+  top: 0;
+  height: 3.5rem;
+  z-index: 50;
+  backdrop-filter: blur(10px);
+  transition: all .3s ease;
+}
+
+/* Slide-down mobile navigation */
+.mobile-nav {
+  position: fixed;
+  top: 3.5rem;
+  left: 0;
+  right: 0;
+  transform: translateY(-100%);
+  transition: transform .3s ease;
+  z-index: 40;
+}
+.mobile-nav.open {
+  transform: translateY(0);
+}
+
+/* Backdrop for mobile navigation */
+.mobile-nav-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.5);
+  display: none;
+  z-index: 30;
+}
+.mobile-nav-backdrop.open {
+  display: block;
+}
+
+/* Compact hero section on small screens */
+@media (max-width: 640px) {
+  .hero {
+    padding-top: 2rem;
+    padding-bottom: 2rem;
+  }
+  /* Avatar-only profile chip */
+  #profile-link .label {
+    display: none;
+  }
+  #profile-link #profile-avatar {
+    margin-right: 0;
+  }
+}
+
+/* Enlarged tap targets for navigation links */
+.nav-link {
+  display: block;
+  padding: 0.75rem 1rem;
+  min-height: 44px;
+}

--- a/public/resources/site.js
+++ b/public/resources/site.js
@@ -1,0 +1,64 @@
+// Apply saved theme immediately and sync across tabs
+(function() {
+  const applyTheme = () => {
+    if (localStorage.theme === 'dark') {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  };
+  applyTheme();
+  window.addEventListener('storage', (e) => {
+    if (e.key === 'theme') applyTheme();
+  });
+
+  document.addEventListener('DOMContentLoaded', () => {
+    // Theme toggle
+    const themeToggle = document.getElementById('theme-toggle');
+    if (themeToggle) {
+      themeToggle.addEventListener('click', () => {
+        document.documentElement.classList.toggle('dark');
+        localStorage.theme = document.documentElement.classList.contains('dark') ? 'dark' : 'light';
+        applyTheme();
+      });
+    }
+
+    // Mobile navigation toggle
+    const menuBtn = document.getElementById('menu-button');
+    const mobileNav = document.querySelector('.mobile-nav');
+    const backdrop = document.getElementById('menu-backdrop');
+    if (menuBtn && mobileNav && backdrop) {
+      const openNav = () => {
+        mobileNav.classList.add('open');
+        backdrop.classList.add('open');
+        menuBtn.setAttribute('aria-expanded', 'true');
+      };
+      const closeNav = () => {
+        mobileNav.classList.remove('open');
+        backdrop.classList.remove('open');
+        menuBtn.setAttribute('aria-expanded', 'false');
+      };
+      menuBtn.addEventListener('click', () => {
+        const expanded = menuBtn.getAttribute('aria-expanded') === 'true';
+        expanded ? closeNav() : openNav();
+      });
+      backdrop.addEventListener('click', closeNav);
+    }
+
+    // Handle auth links in mobile menu
+    document.addEventListener('auth:ready', () => {
+      const links = document.getElementById('mobile-menu-links');
+      if (!links) return;
+      const profileLink = document.getElementById('profile-link-mobile');
+      const adminLink = document.getElementById('admin-link-mobile');
+      const isAdmin = document.documentElement.dataset.admin === 'true';
+      const isAuth = document.documentElement.dataset.auth === 'true';
+      if (profileLink) {
+        profileLink.classList.toggle('hidden', !isAuth);
+      }
+      if (adminLink) {
+        adminLink.classList.toggle('hidden', !isAdmin);
+      }
+    });
+  });
+})();


### PR DESCRIPTION
## Summary
- style sticky top bar and slide-down mobile nav
- centralize theme handling and auth-aware mobile menu links
- collapse profile avatars to initials on small screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f27149e7483288025a7cec1792810