### PR TITLE
Inject Auth0 audience into all public pages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,5 +14,6 @@ AUTH0_ISSUER_BASE_URL=https://your-tenant.auth0.com
 # Auth0 application credentials (use the production app's values in production)
 AUTH0_CLIENT_ID=your-auth0-client-id
 AUTH0_CLIENT_SECRET=your-auth0-client-secret
+# Auth0 audience for API (injected into public pages like /admin)
 AUTH0_AUDIENCE=https://ai-news-hub.api
 

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -6,7 +6,7 @@
   <title>Admin Dashboard</title>
   <meta name="auth0-client-id" content="a2MdQnWFC2HOqBY09V4EZ7KOFjj3fXNK"><!-- Auth0 Client ID injected at build time -->
   <meta name="auth0-domain" content="dev-zi3ojkfg51ob4f3c.eu.auth0.com"><!-- Auth0 Domain injected at build time -->
-  <meta name="auth0-audience" content="__INJECTED__" />
+  <meta name="auth0-audience" content="https://ai-news-hub.api" />
   <script src="https://cdn.auth0.com/js/auth0-spa-js/2.1/auth0-spa-js.production.js" defer></script>
   <script src="/auth/auth.js" defer></script>
   <script src="https://cdn.tailwindcss.com"></script>

--- a/public/auth/callback.html
+++ b/public/auth/callback.html
@@ -6,7 +6,7 @@
   <title>Auth Callback</title>
   <meta name="auth0-client-id" content="a2MdQnWFC2HOqBY09V4EZ7KOFjj3fXNK"><!-- Auth0 Client ID injected at build time -->
   <meta name="auth0-domain" content="dev-zi3ojkfg51ob4f3c.eu.auth0.com"><!-- Auth0 Domain injected at build time -->
-  <meta name="auth0-audience" content="__INJECTED__" />
+  <meta name="auth0-audience" content="https://ai-news-hub.api" />
   <script src="https://cdn.auth0.com/js/auth0-spa-js/2.1/auth0-spa-js.production.js"></script>
   <script src="/auth/auth.js"></script>
 </head>

--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,7 @@
 
   <meta name="auth0-client-id" content="a2MdQnWFC2HOqBY09V4EZ7KOFjj3fXNK"><!-- Auth0 Client ID injected at build time -->
   <meta name="auth0-domain" content="dev-zi3ojkfg51ob4f3c.eu.auth0.com"><!-- Auth0 Domain injected at build time -->
-  <meta name="auth0-audience" content="__INJECTED__" />
+  <meta name="auth0-audience" content="https://ai-news-hub.api" />
   <script src="https://cdn.auth0.com/js/auth0-spa-js/2.1/auth0-spa-js.production.js" defer></script>
   <script src="/auth/auth.js" defer></script>
 

--- a/public/login/index.html
+++ b/public/login/index.html
@@ -6,7 +6,7 @@
   <title>Sign in</title>
   <meta name="auth0-client-id" content="a2MdQnWFC2HOqBY09V4EZ7KOFjj3fXNK"><!-- Auth0 Client ID injected at build time -->
   <meta name="auth0-domain" content="dev-zi3ojkfg51ob4f3c.eu.auth0.com"><!-- Auth0 Domain injected at build time -->
-  <meta name="auth0-audience" content="__INJECTED__" />
+  <meta name="auth0-audience" content="https://ai-news-hub.api" />
   <script src="https://cdn.auth0.com/js/auth0-spa-js/2.1/auth0-spa-js.production.js" defer></script>
   <script src="/auth/auth.js" defer></script>
 </head>

--- a/public/post.html
+++ b/public/post.html
@@ -8,7 +8,7 @@
   <link rel="canonical" href="/post.html" />
   <meta name="auth0-client-id" content="a2MdQnWFC2HOqBY09V4EZ7KOFjj3fXNK"><!-- Auth0 Client ID injected at build time -->
   <meta name="auth0-domain" content="dev-zi3ojkfg51ob4f3c.eu.auth0.com"><!-- Auth0 Domain injected at build time -->
-  <meta name="auth0-audience" content="__INJECTED__" />
+  <meta name="auth0-audience" content="https://ai-news-hub.api" />
   <script src="https://cdn.auth0.com/js/auth0-spa-js/2.1/auth0-spa-js.production.js" defer></script>
   <script src="/auth/auth.js" defer></script>
   <!-- Tailwind & Icons -->

--- a/public/profile.html
+++ b/public/profile.html
@@ -6,7 +6,7 @@
   <title>Your Profile</title>
   <meta name="auth0-client-id" content="a2MdQnWFC2HOqBY09V4EZ7KOFjj3fXNK"><!-- Auth0 Client ID injected at build time -->
   <meta name="auth0-domain" content="dev-zi3ojkfg51ob4f3c.eu.auth0.com"><!-- Auth0 Domain injected at build time -->
-  <meta name="auth0-audience" content="__INJECTED__" />
+  <meta name="auth0-audience" content="https://ai-news-hub.api" />
   <script src="https://cdn.auth0.com/js/auth0-spa-js/2.1/auth0-spa-js.production.js" defer></script>
   <script src="/auth/auth.js" defer></script>
   <script src="https://cdn.tailwindcss.com"></script>

--- a/public/signup/index.html
+++ b/public/signup/index.html
@@ -6,7 +6,7 @@
   <title>Sign up</title>
   <meta name="auth0-client-id" content="a2MdQnWFC2HOqBY09V4EZ7KOFjj3fXNK"><!-- Auth0 Client ID injected at build time -->
   <meta name="auth0-domain" content="dev-zi3ojkfg51ob4f3c.eu.auth0.com"><!-- Auth0 Domain injected at build time -->
-  <meta name="auth0-audience" content="__INJECTED__" />
+  <meta name="auth0-audience" content="https://ai-news-hub.api" />
   <script src="https://cdn.auth0.com/js/auth0-spa-js/2.1/auth0-spa-js.production.js" defer></script>
   <script src="/auth/auth.js" defer></script>
 </head>

--- a/scripts/inject-auth0.js
+++ b/scripts/inject-auth0.js
@@ -10,17 +10,27 @@ if (!clientId || !domain || !audience) {
   process.exit(1);
 }
 
-const files = [
-  'public/index.html',
-  'public/login/index.html',
-  'public/signup/index.html',
-  'public/auth/callback.html',
-  'public/profile.html',
-  'public/post.html'
-];
+const rootDir = path.join(__dirname, '..');
+const publicDir = path.join(rootDir, 'public');
+
+function getHtmlFiles(dir) {
+  const dirents = fs.readdirSync(dir, { withFileTypes: true });
+  let results = [];
+  for (const dirent of dirents) {
+    const fullPath = path.join(dir, dirent.name);
+    if (dirent.isDirectory()) {
+      results = results.concat(getHtmlFiles(fullPath));
+    } else if (dirent.isFile() && path.extname(dirent.name) === '.html') {
+      results.push(path.relative(rootDir, fullPath));
+    }
+  }
+  return results;
+}
+
+const files = getHtmlFiles(publicDir);
 
 for (const file of files) {
-  const filePath = path.join(__dirname, '..', file);
+  const filePath = path.join(rootDir, file);
   const src = fs.readFileSync(filePath, 'utf8');
   const updated = src
     .replace(/\$\{AUTH0_CLIENT_ID\}/g, clientId)


### PR DESCRIPTION
## Summary
- discover public HTML files dynamically when injecting Auth0 config
- inject AUTH0_AUDIENCE into admin and other pages via build script
- clarify Auth0 audience usage in `.env.example`

## Testing
- `npm run inject:auth0`
- `npm test`


