### PR TITLE
Expose sign-in controls and add mobile link

### DIFF
--- a/public/auth/auth.js
+++ b/public/auth/auth.js
@@ -24,28 +24,22 @@
       }
       console.debug('Auth state', { isAuthenticated: isAuth, hasToken });
     }
-    if (isAuth) {
-      if (signInBtn) signInBtn.classList.add('hidden');
-      if (profileLink) profileLink.classList.remove('hidden');
-      if (profileAvatar) {
-        if (user && user.picture) {
-          profileAvatar.src = user.picture;
-          profileAvatar.classList.remove('hidden');
-        } else {
-          profileAvatar.classList.add('hidden');
-          profileAvatar.removeAttribute('src');
-        }
-      }
-      toggleMobileProfileLink(true);
-    } else {
-      if (signInBtn) signInBtn.classList.remove('hidden');
-      if (profileLink) profileLink.classList.add('hidden');
-      if (profileAvatar) {
+    if (signInBtn) {
+      signInBtn.classList.toggle('hidden', isAuth);
+    }
+    if (profileLink) {
+      profileLink.classList.toggle('hidden', !isAuth);
+    }
+    if (profileAvatar) {
+      if (isAuth && user && user.picture) {
+        profileAvatar.src = user.picture;
+        profileAvatar.classList.remove('hidden');
+      } else {
         profileAvatar.classList.add('hidden');
         profileAvatar.removeAttribute('src');
       }
-      toggleMobileProfileLink(false);
     }
+    toggleMobileProfileLink(isAuth);
     if (signOutBtn) {
       signOutBtn.onclick = () => window.auth.logout();
     }

--- a/public/index.html
+++ b/public/index.html
@@ -125,7 +125,7 @@
           </div>
 
           <div id="auth-area" class="flex items-center gap-2">
-            <button id="sign-in-btn" onclick="(sessionStorage.setItem('postLoginRedirect', location.pathname+location.search), auth.login())" class="nav-link hidden rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Sign in</button>
+            <button id="sign-in-btn" onclick="(sessionStorage.setItem('postLoginRedirect', location.pathname+location.search), auth.login())" class="nav-link rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Sign in</button>
             <a id="profile-link" href="/profile.html" class="nav-link hidden rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800 flex items-center">
               <img id="profile-avatar" class="w-6 h-6 rounded-full mr-2 hidden" alt="Profile avatar" />
               <span class="label">Profile</span>
@@ -152,6 +152,7 @@
       <a href="#chatgpt" class="nav-link rounded hover:bg-slate-100 dark:hover:bg-slate-800">ChatGPT Updates</a>
       <a href="#industry" class="nav-link rounded hover:bg-slate-100 dark:hover:bg-slate-800">AI Industry</a>
       <a href="#research" class="nav-link rounded hover:bg-slate-100 dark:hover:bg-slate-800">Research &amp; Innovation</a>
+      <a id="sign-in-link-mobile" href="#" class="nav-link hidden rounded hover:bg-slate-100 dark:hover:bg-slate-800">Sign in</a>
       <a id="profile-link-mobile" href="/profile.html" class="nav-link hidden rounded hover:bg-slate-100 dark:hover:bg-slate-800">Profile</a>
       <a id="admin-link-mobile" href="/admin.html" class="nav-link hidden rounded hover:bg-slate-100 dark:hover:bg-slate-800">Admin</a>
     </div>

--- a/public/resources/site.js
+++ b/public/resources/site.js
@@ -42,12 +42,23 @@
       backdrop.addEventListener('click', closeNav);
     }
 
+    // Handle sign-in link click
+    const signInLinkMobile = document.getElementById('sign-in-link-mobile');
+    if (signInLinkMobile) {
+      signInLinkMobile.addEventListener('click', (e) => {
+        e.preventDefault();
+        sessionStorage.setItem('postLoginRedirect', location.pathname + location.search);
+        if (window.auth) window.auth.login();
+      });
+    }
+
     // Handle auth links in mobile menu
     document.addEventListener('auth:ready', () => {
       const links = document.getElementById('mobile-menu-links');
       if (!links) return;
       const profileLink = document.getElementById('profile-link-mobile');
       const adminLink = document.getElementById('admin-link-mobile');
+      const signInLink = document.getElementById('sign-in-link-mobile');
       const isAdmin = document.documentElement.dataset.admin === 'true';
       const isAuth = document.documentElement.dataset.auth === 'true';
       if (profileLink) {
@@ -55,6 +66,9 @@
       }
       if (adminLink) {
         adminLink.classList.toggle('hidden', !isAdmin);
+      }
+      if (signInLink) {
+        signInLink.classList.toggle('hidden', isAuth);
       }
     });
   });


### PR DESCRIPTION
## Summary
- Show desktop sign-in button by default and hide it only when authenticated
- Add a hidden-by-default "Sign in" link to the mobile menu with login handler
- Toggle mobile auth links based on authentication state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f80fdcb908328b1ca33d08b961240