### PR TITLE
Handle profile link visibility in site.js

### DIFF
--- a/public/auth/auth.js
+++ b/public/auth/auth.js
@@ -9,7 +9,6 @@
   
   async function updateAuthUI() {
     if (!window.auth) return;
-    const profileLink = document.getElementById('profile-link') || document.getElementById('dashboard-link');
     const profileAvatar = document.getElementById('profile-avatar');
     signInBtn = document.getElementById('sign-in-btn');
     signOutBtn = document.getElementById('sign-out-btn') || document.getElementById('logout-btn');
@@ -27,9 +26,6 @@
     if (signInBtn) {
       signInBtn.classList.toggle('hidden', isAuth);
     }
-    if (profileLink) {
-      profileLink.classList.toggle('hidden', !isAuth);
-    }
     if (profileAvatar) {
       if (isAuth && user && user.picture) {
         profileAvatar.src = user.picture;
@@ -39,7 +35,6 @@
         profileAvatar.removeAttribute('src');
       }
     }
-    toggleMobileProfileLink(isAuth);
     if (signOutBtn) {
       signOutBtn.onclick = () => window.auth.logout();
     }
@@ -48,13 +43,6 @@
   function debouncedUpdateAuthUI() {
     clearTimeout(updateAuthUITimer);
     updateAuthUITimer = setTimeout(updateAuthUI, 100);
-  }
-
-  function toggleMobileProfileLink(show) {
-    const mobileProfileLink = document.getElementById('profile-link-mobile');
-    if (mobileProfileLink) {
-      mobileProfileLink.classList.toggle('hidden', !show);
-    }
   }
 
   function showAuthError() {
@@ -242,7 +230,6 @@
 
     window.getApiToken = getApiToken;
     window.updateAuthUI = debouncedUpdateAuthUI;
-    window.toggleMobileProfileLink = toggleMobileProfileLink;
 
     window.authReady = window.authReady.then(refreshAuthState);
 

--- a/public/resources/site.css
+++ b/public/resources/site.css
@@ -49,6 +49,12 @@
   #profile-link #profile-avatar {
     margin-right: 0;
   }
+  #profile-link-mobile .label {
+    display: none;
+  }
+  #profile-link-mobile #profile-avatar {
+    margin-right: 0;
+  }
 }
 
 /* Enlarged tap targets for navigation links */

--- a/public/resources/site.js
+++ b/public/resources/site.js
@@ -52,17 +52,19 @@
       });
     }
 
-    // Handle auth links in mobile menu
+    // Handle auth link visibility
     document.addEventListener('auth:ready', () => {
-      const links = document.getElementById('mobile-menu-links');
-      if (!links) return;
-      const profileLink = document.getElementById('profile-link-mobile');
+      const profileLinkDesktop = document.getElementById('profile-link') || document.getElementById('dashboard-link');
+      const profileLinkMobile = document.getElementById('profile-link-mobile');
       const adminLink = document.getElementById('admin-link-mobile');
       const signInLink = document.getElementById('sign-in-link-mobile');
       const isAdmin = document.documentElement.dataset.admin === 'true';
       const isAuth = document.documentElement.dataset.auth === 'true';
-      if (profileLink) {
-        profileLink.classList.toggle('hidden', !isAuth);
+      if (profileLinkDesktop) {
+        profileLinkDesktop.classList.toggle('hidden', !isAuth);
+      }
+      if (profileLinkMobile) {
+        profileLinkMobile.classList.toggle('hidden', !isAuth);
       }
       if (adminLink) {
         adminLink.classList.toggle('hidden', !isAdmin);


### PR DESCRIPTION
## Summary
- Remove obsolete mobile profile link toggling from `auth.js`
- Centralize profile link visibility in `site.js`'s `auth:ready` handler
- Add CSS rule ensuring mobile profile link remains avatar-only

## Testing
- `npm test`
