### PR TITLE
Expose getApiToken via auth object

### DIFF
--- a/public/auth/auth.js
+++ b/public/auth/auth.js
@@ -153,6 +153,7 @@
       getUser: () => withClient(() => auth0Client.getUser(), null),
       isAuthenticated: () => withClient(() => auth0Client.isAuthenticated(), false),
       getIdTokenClaims: () => withClient(() => auth0Client.getIdTokenClaims(), null),
+      getApiToken,
       handleRedirectCallback: () =>
         withClient(async () => {
           const res = await handleRedirectCallbackSafe();
@@ -228,7 +229,6 @@
       debouncedUpdateAuthUI();
     }
 
-    window.getApiToken = getApiToken;
     window.updateAuthUI = debouncedUpdateAuthUI;
 
     window.authReady = window.authReady.then(refreshAuthState);

--- a/public/post.html
+++ b/public/post.html
@@ -64,7 +64,7 @@
         const textarea = document.getElementById('comment-content');
         const content = textarea.value.trim();
         if (!content) return;
-        const token = await getApiToken();
+        const token = await auth.getApiToken();
         const res = await fetch('/api/comments', {
           method: 'POST',
           headers: {
@@ -129,7 +129,7 @@
           const btn = e.target.closest('.comment-delete');
           if (btn) {
             const id = btn.dataset.id;
-            const token = await getApiToken();
+            const token = await auth.getApiToken();
             const res = await fetch(`/api/comments/${id}`, {
               method: 'DELETE',
               headers: { 'Authorization': `Bearer ${token}` }


### PR DESCRIPTION
## Summary
- include `getApiToken` on the `window.auth` object
- switch post page to use `auth.getApiToken()`

## Testing
- `npm test`

