### PR TITLE
chore: load shared site assets in admin

### DIFF
--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -15,6 +15,8 @@
   <script src="/auth/auth.js" defer></script>
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="/resources/site.css">
+  <script src="/resources/site.js" defer></script>
 </head>
 <body class="p-6 bg-light dark:bg-dark">
   <h1 class="text-2xl font-bold mb-6 flex items-center gap-2"><i class="fa-solid fa-lock"></i> Admin Dashboard</h1>


### PR DESCRIPTION
## Summary
- load `/resources/site.css` and `/resources/site.js` on the admin dashboard so it uses shared styles and scripts

## Testing
- `npm test`
- Node + jsdom simulation verifying theme persistence and mobile nav toggling

