### PR TITLE
Keep sign-in button enabled when Auth0 init fails

### DIFF
--- a/public/auth/auth.js
+++ b/public/auth/auth.js
@@ -49,8 +49,8 @@
     if (authErrorShown) return;
     authErrorShown = true;
     if (signInBtn) {
-      signInBtn.disabled = true;
-      signInBtn.classList.add('opacity-50', 'cursor-not-allowed');
+      signInBtn.disabled = false;
+      signInBtn.classList.remove('opacity-50', 'cursor-not-allowed');
     }
     if (!document.getElementById('auth-error')) {
       const msg = document.createElement('div');
@@ -89,7 +89,6 @@
     const redirect_uri = window.location.origin + '/auth/callback.html';
     if (authDebug) console.debug('Auth0 config', { domain, clientId, redirect_uri, audience: AUDIENCE });
     signInBtn = document.getElementById('sign-in-btn');
-    if (signInBtn) signInBtn.disabled = true;
 
     window.authReady = (async () => {
       try {
@@ -128,9 +127,11 @@
       if (!auth0Client) {
         showAuthError();
         if (authDebug) console.debug('Auth0 client unavailable');
-      } else if (signInBtn) {
+      }
+      if (signInBtn) {
         signInBtn.disabled = false;
-        if (authDebug) console.debug('Auth0 ready');
+        signInBtn.classList.remove('opacity-50', 'cursor-not-allowed');
+        if (auth0Client && authDebug) console.debug('Auth0 ready');
       }
     })();
 


### PR DESCRIPTION
## Summary
- Avoid disabling the sign-in button during Auth0 initialization
- Always re-enable the sign-in button and remove disabled styling after Auth0 init attempts
- Show banner without disabling the button when authentication is unavailable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fa6f2602c832882f32aa58a96863b