### PR TITLE
Handle sign-in button through site script

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -125,7 +125,7 @@
           </div>
 
           <div id="auth-area" class="flex items-center gap-2">
-            <button id="sign-in-btn" onclick="(sessionStorage.setItem('postLoginRedirect', location.pathname+location.search), auth.login())" class="nav-link rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Sign in</button>
+            <button id="sign-in-btn" class="nav-link rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Sign in</button>
             <a id="profile-link" href="/profile.html" class="nav-link hidden rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800 flex items-center">
               <img id="profile-avatar" class="w-6 h-6 rounded-full mr-2 hidden" alt="Profile avatar" />
               <span class="label">Profile</span>

--- a/public/resources/site.js
+++ b/public/resources/site.js
@@ -52,6 +52,15 @@
       });
     }
 
+    // Handle desktop sign-in button
+    const desktopBtn = document.getElementById('sign-in-btn');
+    if (desktopBtn) {
+      desktopBtn.addEventListener('click', () => {
+        sessionStorage.setItem('postLoginRedirect', location.pathname + location.search);
+        if (window.auth) window.auth.login();
+      });
+    }
+
     // Handle auth link visibility
     document.addEventListener('auth:ready', () => {
       const profileLinkDesktop = document.getElementById('profile-link') || document.getElementById('dashboard-link');


### PR DESCRIPTION
## Summary
- remove inline `onclick` from sign-in button in homepage
- register desktop sign-in button handler in `site.js` mirroring mobile link

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fa83d7c98832892f7c076f9e14812