### PR TITLE
fix: remove optional chaining for older browsers

### DIFF
--- a/public/auth/auth.js
+++ b/public/auth/auth.js
@@ -5,7 +5,8 @@
   let signOutBtn;
   let updateAuthUITimer;
   const authDebug = new URLSearchParams(window.location.search).get('auth_debug') === '1';
-  const AUDIENCE = document.querySelector('meta[name="auth0-audience"]')?.content;
+  const audMeta = document.querySelector('meta[name="auth0-audience"]');
+  const AUDIENCE = audMeta ? audMeta.content : '';
   
   async function updateAuthUI() {
     if (!window.auth) return;

--- a/public/index.html
+++ b/public/index.html
@@ -365,7 +365,7 @@
         <article class="post-card bg-white dark:bg-slate-800 rounded-xl overflow-hidden shadow-lg">
           <div class="relative">
             <img src="${p.hero_image || p.image_url || 'https://picsum.photos/800/400'}" alt="${p.title}" loading="lazy" class="w-full h-56 object-cover">
-            ${p.tags?.includes('Release') ? '<span class="absolute top-4 right-4 bg-primary text-white text-xs font-semibold px-3 py-1 rounded-full">New</span>' : ''}
+            ${p.tags && p.tags.includes('Release') ? '<span class="absolute top-4 right-4 bg-primary text-white text-xs font-semibold px-3 py-1 rounded-full">New</span>' : ''}
           </div>
           <div class="p-6">
             <div class="flex items-center text-sm text-slate-500 dark:text-slate-400 mb-3">
@@ -441,7 +441,7 @@
         searchInput.addEventListener('input', () => {
           const q = searchInput.value.trim().toLowerCase();
           if (q.length < 2) { searchResults.classList.add('hidden'); return; }
-          const matches = posts.filter(p => p.title?.toLowerCase().includes(q)).slice(0,8);
+          const matches = posts.filter(p => p.title && p.title.toLowerCase().includes(q)).slice(0,8);
           searchResults.innerHTML = matches.length
             ? matches.map(m => `
               <a class="block p-3 hover:bg-slate-100 dark:hover:bg-slate-700 border-b border-slate-200 dark:border-slate-700 last:border-0" href="/post.html?slug=${encodeURIComponent(m.slug)}">

--- a/public/post.html
+++ b/public/post.html
@@ -44,7 +44,7 @@
               <div class="border-b pb-2">
                 <div class="flex items-center justify-between mb-1">
                   <div class="text-sm text-slate-500">${c.name || 'Anonymous'} &bull; ${new Date(c.created_at).toLocaleString()}</div>
-                  ${currentUser && (currentUser.sub === c.user_id || window.__auth?.isAdmin)
+                  ${currentUser && (currentUser.sub === c.user_id || (window.__auth && window.__auth.isAdmin))
                     ? `<button data-id="${c.id}" class="comment-delete text-xs text-red-500 hover:underline">Delete</button>`
                     : ''}
                 </div>


### PR DESCRIPTION
## Summary
- replace optional chaining in auth initialization with guarded lookups
- guard tag and title checks in index page to avoid optional chaining
- ensure comment admin check doesn't rely on optional chaining

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fb9dfef6c83288ba786a4c8a36369