### PR TITLE
Remove extra Research & Innovation references

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -116,7 +116,6 @@
           <a href="#openai"   class="nav-link rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">OpenAI News</a>
           <a href="#chatgpt"  class="nav-link rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">ChatGPT Updates</a>
           <a href="#industry" class="nav-link rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">AI Industry</a>
-          <a href="#research" class="nav-link rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Research & Innovation</a>
         </nav>
 
         <div class="flex items-center gap-4">
@@ -153,7 +152,6 @@
       <a href="#openai" class="nav-link rounded hover:bg-slate-100 dark:hover:bg-slate-800">OpenAI News</a>
       <a href="#chatgpt" class="nav-link rounded hover:bg-slate-100 dark:hover:bg-slate-800">ChatGPT Updates</a>
       <a href="#industry" class="nav-link rounded hover:bg-slate-100 dark:hover:bg-slate-800">AI Industry</a>
-      <a href="#research" class="nav-link rounded hover:bg-slate-100 dark:hover:bg-slate-800">Research &amp; Innovation</a>
       <a id="sign-in-link-mobile" href="#" class="nav-link hidden rounded hover:bg-slate-100 dark:hover:bg-slate-800">Sign in</a>
       <a id="profile-link-mobile" href="/profile.html" class="nav-link hidden rounded hover:bg-slate-100 dark:hover:bg-slate-800">Profile</a>
       <a id="admin-link-mobile" href="/admin/" class="nav-link hidden rounded hover:bg-slate-100 dark:hover:bg-slate-800">Admin</a>
@@ -276,7 +274,6 @@
             <li><a href="#openai"   class="hover:text-white">OpenAI News</a></li>
             <li><a href="#chatgpt"  class="hover:text-white">ChatGPT Updates</a></li>
             <li><a href="#industry" class="hover:text-white">AI Industry News</a></li>
-            <li><a href="#research" class="hover:text-white">Research & Innovation</a></li>
           </ul>
         </div>
 


### PR DESCRIPTION
## Summary
- Drop Research & Innovation links from header, mobile menu, and footer to avoid duplicate headings
- Ensure only the #research section retains the "Research & Innovation" heading

## Testing
- `npm test`

