### PR TITLE
Handle auth initialization failures gracefully

### DIFF
--- a/public/auth/auth.js
+++ b/public/auth/auth.js
@@ -49,10 +49,7 @@
   function showAuthError() {
     if (authErrorShown) return;
     authErrorShown = true;
-    if (signInBtn) {
-      signInBtn.disabled = false;
-      signInBtn.classList.remove('opacity-50', 'cursor-not-allowed');
-    }
+    // Ensure UI shows an error without altering sign-in button state
     if (!document.getElementById('auth-error')) {
       const msg = document.createElement('div');
       msg.id = 'auth-error';
@@ -149,11 +146,7 @@
         showAuthError();
         if (authDebug) console.debug('Auth0 client unavailable');
       }
-      if (signInBtn) {
-        signInBtn.disabled = false;
-        signInBtn.classList.remove('opacity-50', 'cursor-not-allowed');
-        if (auth0Client && authDebug) console.debug('Auth0 ready');
-      }
+      if (auth0Client && authDebug) console.debug('Auth0 ready');
     })();
 
     window.auth = {

--- a/public/resources/site.js
+++ b/public/resources/site.js
@@ -48,7 +48,13 @@
       signInLinkMobile.addEventListener('click', (e) => {
         e.preventDefault();
         sessionStorage.setItem('postLoginRedirect', location.pathname + location.search);
-        if (window.auth) window.auth.login();
+        if (window.auth) {
+          window.auth.login();
+        } else if (typeof showToast === 'function') {
+          showToast('Authentication is currently unavailable. Please try again later.');
+        } else {
+          alert('Authentication is currently unavailable. Please try again later.');
+        }
       });
     }
 
@@ -57,7 +63,13 @@
     if (desktopBtn) {
       desktopBtn.addEventListener('click', () => {
         sessionStorage.setItem('postLoginRedirect', location.pathname + location.search);
-        if (window.auth) window.auth.login();
+        if (window.auth) {
+          window.auth.login();
+        } else if (typeof showToast === 'function') {
+          showToast('Authentication is currently unavailable. Please try again later.');
+        } else {
+          alert('Authentication is currently unavailable. Please try again later.');
+        }
       });
     }
 


### PR DESCRIPTION
## Summary
- Remove sign-in button disabling and cursor state changes when Auth0 fails to initialize
- Show a toast or alert when sign-in is attempted without an active auth client

## Testing
- `npm test`
- `npx playwright install webkit` *(fails: ERR_SOCKET_CLOSED)*

