### PR TITLE
Use sign-in links to support non-JS login

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -126,7 +126,7 @@
           </div>
 
           <div id="auth-area" class="flex items-center gap-2">
-            <button id="sign-in-btn" class="nav-link rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Sign in</button>
+            <a id="sign-in-btn" href="/login/" class="nav-link rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Sign in</a>
             <a id="profile-link" href="/profile.html" class="nav-link hidden rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800 flex items-center">
               <img id="profile-avatar" class="w-6 h-6 rounded-full mr-2 hidden" alt="Profile avatar" />
               <span class="label">Profile</span>
@@ -153,7 +153,7 @@
       <a href="#openai" class="nav-link rounded hover:bg-slate-100 dark:hover:bg-slate-800">OpenAI News</a>
       <a href="#chatgpt" class="nav-link rounded hover:bg-slate-100 dark:hover:bg-slate-800">ChatGPT Updates</a>
       <a href="#industry" class="nav-link rounded hover:bg-slate-100 dark:hover:bg-slate-800">AI Industry</a>
-      <a id="sign-in-link-mobile" href="#" class="nav-link hidden rounded hover:bg-slate-100 dark:hover:bg-slate-800">Sign in</a>
+      <a id="sign-in-link-mobile" href="/login/" class="nav-link rounded hover:bg-slate-100 dark:hover:bg-slate-800">Sign in</a>
       <a id="profile-link-mobile" href="/profile.html" class="nav-link hidden rounded hover:bg-slate-100 dark:hover:bg-slate-800">Profile</a>
       <a id="admin-link-mobile" href="/admin/" class="nav-link hidden rounded hover:bg-slate-100 dark:hover:bg-slate-800">Admin</a>
     </div>

--- a/public/resources/site.js
+++ b/public/resources/site.js
@@ -61,7 +61,8 @@
     // Handle desktop sign-in button
     const desktopBtn = document.getElementById('sign-in-btn');
     if (desktopBtn) {
-      desktopBtn.addEventListener('click', () => {
+      desktopBtn.addEventListener('click', (e) => {
+        e.preventDefault();
         sessionStorage.setItem('postLoginRedirect', location.pathname + location.search);
         if (window.auth) {
           window.auth.login();


### PR DESCRIPTION
## Summary
- Use anchor links for sign-in, pointing to `/login/`
- Make mobile sign-in link visible by default
- Prevent default sign-in link navigation when JS handles auth

## Testing
- `npm test`

