### PR TITLE
Bootstrap auth early and simplify initialization

### DIFF
--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -49,15 +49,11 @@
     </div>
   </section>
 
-  <script>
-    window.addEventListener('DOMContentLoaded', async () => {
-      initAuth();
-      await window.authReady;
-      if (document.documentElement.dataset.admin !== 'true') {
-        window.location.replace('/profile.html?unauthorized=1');
-        return;
-      }
-    });
+  <script type="module">
+    await window.authReady;
+    if (document.documentElement.dataset.admin !== 'true') {
+      window.location.replace('/profile.html?unauthorized=1');
+    }
   </script>
 </body>
 </html>

--- a/public/auth/auth.js
+++ b/public/auth/auth.js
@@ -61,6 +61,7 @@
       alert('Authentication is currently unavailable. Please try again later.');
     }
   }
+  window.showAuthError = showAuthError;
 
   // Show an auth error if the Auth0 SDK script fails to load
   const auth0Script = document.querySelector('script[src*="auth0-spa-js"]');
@@ -99,6 +100,11 @@
     const redirect_uri = window.location.origin + '/auth/callback.html';
     if (authDebug) console.debug('Auth0 config', { domain, clientId, redirect_uri, audience: AUDIENCE });
     signInBtn = document.getElementById('sign-in-btn');
+    if (!domain || !clientId) {
+      showAuthError();
+      window.authReady = Promise.resolve();
+      return window.authReady;
+    }
     const sdkLoaded =
       typeof createAuth0Client === 'function' ||
       (window.auth0 && typeof window.auth0.createAuth0Client === 'function');
@@ -250,4 +256,5 @@
 
     return window.authReady;
   };
+  window.initAuth();
 })();

--- a/public/auth/callback.html
+++ b/public/auth/callback.html
@@ -15,31 +15,28 @@
   <script src="/auth/auth.js"></script>
 </head>
 <body>
-  <script>
-    window.addEventListener('DOMContentLoaded', async () => {
-      initAuth();
-      await window.authReady;
-      try {
-        if (!window.__handledAuthRedirect) {
-          window.__handledAuthRedirect = true;
-          await auth.handleRedirectCallback();
-          const url = new URL(window.location.href);
-          url.searchParams.delete('code');
-          url.searchParams.delete('state');
-          window.history.replaceState({}, document.title, url.pathname + url.search + url.hash);
-        }
-
-        const redirectPath = sessionStorage.getItem('postLoginRedirect');
-        if (redirectPath) {
-          sessionStorage.removeItem('postLoginRedirect');
-          window.location.replace(redirectPath);
-        } else {
-          window.location.replace('/profile.html');
-        }
-      } catch (e) {
-        document.body.innerHTML = `<p>Authentication failed.</p><p><a href="/">Back to home</a></p>`;
+  <script type="module">
+    await window.authReady;
+    try {
+      if (!window.__handledAuthRedirect) {
+        window.__handledAuthRedirect = true;
+        await auth.handleRedirectCallback();
+        const url = new URL(window.location.href);
+        url.searchParams.delete('code');
+        url.searchParams.delete('state');
+        window.history.replaceState({}, document.title, url.pathname + url.search + url.hash);
       }
-    });
+
+      const redirectPath = sessionStorage.getItem('postLoginRedirect');
+      if (redirectPath) {
+        sessionStorage.removeItem('postLoginRedirect');
+        window.location.replace(redirectPath);
+      } else {
+        window.location.replace('/profile.html');
+      }
+    } catch (e) {
+      document.body.innerHTML = `<p>Authentication failed.</p><p><a href="/">Back to home</a></p>`;
+    }
   </script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -472,20 +472,17 @@
     byId('year').textContent = new Date().getFullYear();
 
     if (window.fetch && window.URL) {
-      document.addEventListener('DOMContentLoaded', loadAll);
+      loadAll();
     } else {
       document.getElementById('openai-grid').textContent =
         'Your browser is not supported.';
     }
   </script>
-  <script>
-    window.addEventListener('DOMContentLoaded', async () => {
-      initAuth();
-      await window.authReady;
-      updateAuthUI();
-      document.addEventListener('visibilitychange', () => {
-        if (!document.hidden) updateAuthUI();
-      });
+  <script type="module">
+    await window.authReady;
+    updateAuthUI();
+    document.addEventListener('visibilitychange', () => {
+      if (!document.hidden) updateAuthUI();
     });
   </script>
 </body>

--- a/public/login/index.html
+++ b/public/login/index.html
@@ -16,13 +16,10 @@
 </head>
 <body>
   <p>Redirecting…</p>
-  <script>
-    window.addEventListener('DOMContentLoaded', async () => {
-      initAuth();
-      await window.authReady;
-      sessionStorage.setItem('postLoginRedirect', '/profile.html');
-      auth.login();
-    });
+  <script type="module">
+    await window.authReady;
+    sessionStorage.setItem('postLoginRedirect', '/profile.html');
+    auth.login();
   </script>
 </body>
 </html>

--- a/public/post.html
+++ b/public/post.html
@@ -9,7 +9,7 @@
   <meta name="auth0-client-id" content="a2MdQnWFC2HOqBY09V4EZ7KOFjj3fXNK"><!-- Auth0 Client ID injected at build time -->
   <meta name="auth0-domain" content="dev-zi3ojkfg51ob4f3c.eu.auth0.com"><!-- Auth0 Domain injected at build time -->
   <meta name="auth0-audience" content="https://ai-news-hub.api" />
-  <script>
+  <script type="module">
     document.documentElement.dataset.theme = localStorage.theme || 'light';
     if (document.documentElement.dataset.theme === 'dark') document.documentElement.classList.add('dark');
   </script>
@@ -97,7 +97,6 @@
         const p = await res.json();
         const date = new Date(p.published_at || Date.now()).toLocaleDateString();
 
-        initAuth();
         await window.authReady;
 
         let authHtml = '';
@@ -150,9 +149,7 @@
         container.innerHTML = '<p class="text-red-500">Failed to load article.</p>';
       }
     }
-    document.addEventListener('DOMContentLoaded', () => {
-      loadPost();
-    });
+    loadPost();
   </script>
 </body>
 </html>

--- a/public/profile.html
+++ b/public/profile.html
@@ -44,52 +44,51 @@
     <p id="sub" class="mt-2 text-sm text-slate-500 break-all"></p>
   </details>
   <button id="logout-btn" class="mt-4 w-full sm:w-auto px-4 py-2 bg-secondary text-white rounded hover:bg-cyan-500">Sign out</button>
-  <script>
-    window.addEventListener('DOMContentLoaded', async () => {
-      document.addEventListener('auth:ready', () => {
-        const isAdmin = document.documentElement.dataset.admin === 'true';
-        const links = document.getElementById('profile-links');
-        let adminLink = document.getElementById('admin-link');
-        if (isAdmin) {
-          if (!adminLink) {
-            adminLink = document.createElement('a');
-            adminLink.id = 'admin-link';
-            adminLink.href = '/admin/';
-            adminLink.className = 'px-4 py-2 rounded hover:bg-slate-100 dark:hover:bg-slate-700';
-            adminLink.textContent = 'Admin';
-            links.prepend(adminLink);
-          }
-        } else if (adminLink) {
-          adminLink.remove();
+  <script type="module">
+    function handleAuthReady() {
+      const isAdmin = document.documentElement.dataset.admin === 'true';
+      const links = document.getElementById('profile-links');
+      let adminLink = document.getElementById('admin-link');
+      if (isAdmin) {
+        if (!adminLink) {
+          adminLink = document.createElement('a');
+          adminLink.id = 'admin-link';
+          adminLink.href = '/admin/';
+          adminLink.className = 'px-4 py-2 rounded hover:bg-slate-100 dark:hover:bg-slate-700';
+          adminLink.textContent = 'Admin';
+          links.prepend(adminLink);
         }
-      });
+      } else if (adminLink) {
+        adminLink.remove();
+      }
+    }
 
-      initAuth();
-      await window.authReady;
-      if (!(await auth.isAuthenticated())) {
-        location.replace('/login/index.html');
-        return;
-      }
-      const user = await auth.getUser();
-      const avatarImg = document.getElementById('avatar');
-      const avatarPlaceholder = document.getElementById('avatar-placeholder');
-      const initial = (user.name || user.nickname || '?').charAt(0).toUpperCase();
-      avatarPlaceholder.textContent = initial;
-      if (user.picture) {
-        avatarImg.src = user.picture;
-        avatarImg.classList.remove('hidden');
-      } else {
-        avatarPlaceholder.classList.remove('sm:hidden');
-      }
-      document.getElementById('name').textContent = user.name || user.nickname || '';
-      document.getElementById('email').textContent = user.email || '';
-      document.getElementById('sub').textContent = user.sub || '';
-      if (user.email_verified) {
-        document.getElementById('verified').classList.remove('hidden');
-      }
-      const signOutBtn = document.getElementById('logout-btn');
-      if (signOutBtn) signOutBtn.addEventListener('click', () => auth.logout());
-    });
+    document.addEventListener('auth:ready', handleAuthReady);
+    await window.authReady;
+    handleAuthReady();
+    if (!(await auth.isAuthenticated())) {
+      location.replace('/login/index.html');
+      return;
+    }
+    const user = await auth.getUser();
+    const avatarImg = document.getElementById('avatar');
+    const avatarPlaceholder = document.getElementById('avatar-placeholder');
+    const initial = (user.name || user.nickname || '?').charAt(0).toUpperCase();
+    avatarPlaceholder.textContent = initial;
+    if (user.picture) {
+      avatarImg.src = user.picture;
+      avatarImg.classList.remove('hidden');
+    } else {
+      avatarPlaceholder.classList.remove('sm:hidden');
+    }
+    document.getElementById('name').textContent = user.name || user.nickname || '';
+    document.getElementById('email').textContent = user.email || '';
+    document.getElementById('sub').textContent = user.sub || '';
+    if (user.email_verified) {
+      document.getElementById('verified').classList.remove('hidden');
+    }
+    const signOutBtn = document.getElementById('logout-btn');
+    if (signOutBtn) signOutBtn.addEventListener('click', () => auth.logout());
   </script>
 </body>
 </html>

--- a/public/resources/site.js
+++ b/public/resources/site.js
@@ -10,94 +10,88 @@
     if (e.key === 'theme') applyTheme();
   });
 
-  document.addEventListener('DOMContentLoaded', () => {
-    // Theme toggle
-    const themeToggle = document.getElementById('theme-toggle');
-    if (themeToggle) {
-      themeToggle.addEventListener('click', () => {
-        localStorage.theme = document.documentElement.dataset.theme === 'dark' ? 'light' : 'dark';
-        applyTheme();
-      });
-    }
+  // Theme toggle
+  const themeToggle = document.getElementById('theme-toggle');
+  if (themeToggle) {
+    themeToggle.addEventListener('click', () => {
+      localStorage.theme = document.documentElement.dataset.theme === 'dark' ? 'light' : 'dark';
+      applyTheme();
+    });
+  }
 
-    // Mobile navigation toggle
-    const menuBtn = document.getElementById('menu-button');
-    const mobileNav = document.querySelector('.mobile-nav');
-    const backdrop = document.getElementById('menu-backdrop');
-    if (menuBtn && mobileNav && backdrop) {
-      const openNav = () => {
-        mobileNav.classList.add('open');
-        backdrop.classList.add('open');
-        menuBtn.setAttribute('aria-expanded', 'true');
-      };
-      const closeNav = () => {
-        mobileNav.classList.remove('open');
-        backdrop.classList.remove('open');
-        menuBtn.setAttribute('aria-expanded', 'false');
-      };
-      menuBtn.addEventListener('click', () => {
-        const expanded = menuBtn.getAttribute('aria-expanded') === 'true';
-        expanded ? closeNav() : openNav();
-      });
-      backdrop.addEventListener('click', closeNav);
-    }
+  // Mobile navigation toggle
+  const menuBtn = document.getElementById('menu-button');
+  const mobileNav = document.querySelector('.mobile-nav');
+  const backdrop = document.getElementById('menu-backdrop');
+  if (menuBtn && mobileNav && backdrop) {
+    const openNav = () => {
+      mobileNav.classList.add('open');
+      backdrop.classList.add('open');
+      menuBtn.setAttribute('aria-expanded', 'true');
+    };
+    const closeNav = () => {
+      mobileNav.classList.remove('open');
+      backdrop.classList.remove('open');
+      menuBtn.setAttribute('aria-expanded', 'false');
+    };
+    menuBtn.addEventListener('click', () => {
+      const expanded = menuBtn.getAttribute('aria-expanded') === 'true';
+      expanded ? closeNav() : openNav();
+    });
+    backdrop.addEventListener('click', closeNav);
+  }
 
-    // Handle sign-in link click
-    const signInLinkMobile = document.getElementById('sign-in-link-mobile');
-    if (signInLinkMobile) {
-      signInLinkMobile.addEventListener('click', (e) => {
+  // Handle sign-in link click
+  const signInLinkMobile = document.getElementById('sign-in-link-mobile');
+  if (signInLinkMobile) {
+    signInLinkMobile.addEventListener('click', (e) => {
+      sessionStorage.setItem('postLoginRedirect', location.pathname + location.search);
+      if (window.auth) {
         e.preventDefault();
-        sessionStorage.setItem('postLoginRedirect', location.pathname + location.search);
-        if (window.auth) {
-          window.auth.login();
-        } else if (typeof showToast === 'function') {
-          showToast('Authentication is currently unavailable. Please try again later.');
-        } else {
-          alert('Authentication is currently unavailable. Please try again later.');
-        }
-      });
-    }
-
-    // Handle desktop sign-in button
-    const desktopBtn = document.getElementById('sign-in-btn');
-    if (desktopBtn) {
-      desktopBtn.addEventListener('click', (e) => {
-        e.preventDefault();
-        sessionStorage.setItem('postLoginRedirect', location.pathname + location.search);
-        if (window.auth) {
-          window.auth.login();
-        } else if (typeof showToast === 'function') {
-          showToast('Authentication is currently unavailable. Please try again later.');
-        } else {
-          alert('Authentication is currently unavailable. Please try again later.');
-        }
-      });
-    }
-
-    // Handle auth link visibility
-    document.addEventListener('auth:ready', () => {
-      const profileLinkDesktop = document.getElementById('profile-link') || document.getElementById('dashboard-link');
-      const profileLinkMobile = document.getElementById('profile-link-mobile');
-      const adminLinkDesktop = document.getElementById('admin-link');
-      const adminLinkMobile = document.getElementById('admin-link-mobile');
-      const signInLink = document.getElementById('sign-in-link-mobile');
-      const isAdmin = document.documentElement.dataset.admin === 'true';
-      const isAuth = document.documentElement.dataset.auth === 'true';
-      if (profileLinkDesktop) {
-        profileLinkDesktop.classList.toggle('hidden', !isAuth);
-      }
-      if (profileLinkMobile) {
-        profileLinkMobile.classList.toggle('hidden', !isAuth);
-      }
-      if (adminLinkDesktop) {
-        adminLinkDesktop.classList.toggle('hidden', !isAdmin);
-      }
-      if (adminLinkMobile) {
-        adminLinkMobile.classList.toggle('hidden', !isAdmin);
-      }
-      if (signInLink) {
-        signInLink.classList.toggle('hidden', isAuth);
+        window.auth.login();
+      } else if (window.showAuthError) {
+        window.showAuthError();
       }
     });
+  }
+
+  // Handle desktop sign-in button
+  const desktopBtn = document.getElementById('sign-in-btn');
+  if (desktopBtn) {
+    desktopBtn.addEventListener('click', (e) => {
+      sessionStorage.setItem('postLoginRedirect', location.pathname + location.search);
+      if (window.auth) {
+        e.preventDefault();
+        window.auth.login();
+      } else if (window.showAuthError) {
+        window.showAuthError();
+      }
+    });
+  }
+
+  // Handle auth link visibility
+  document.addEventListener('auth:ready', () => {
+    const profileLinkDesktop = document.getElementById('profile-link') || document.getElementById('dashboard-link');
+    const profileLinkMobile = document.getElementById('profile-link-mobile');
+    const adminLinkDesktop = document.getElementById('admin-link');
+    const adminLinkMobile = document.getElementById('admin-link-mobile');
+    const signInLink = document.getElementById('sign-in-link-mobile');
+    const isAdmin = document.documentElement.dataset.admin === 'true';
+    const isAuth = document.documentElement.dataset.auth === 'true';
+    if (profileLinkDesktop) {
+      profileLinkDesktop.classList.toggle('hidden', !isAuth);
+    }
+    if (profileLinkMobile) {
+      profileLinkMobile.classList.toggle('hidden', !isAuth);
+    }
+    if (adminLinkDesktop) {
+      adminLinkDesktop.classList.toggle('hidden', !isAdmin);
+    }
+    if (adminLinkMobile) {
+      adminLinkMobile.classList.toggle('hidden', !isAdmin);
+    }
+    if (signInLink) {
+      signInLink.classList.toggle('hidden', isAuth);
+    }
   });
 })();

--- a/public/signup/index.html
+++ b/public/signup/index.html
@@ -16,13 +16,10 @@
 </head>
 <body>
   <p>Redirecting…</p>
-  <script>
-    window.addEventListener('DOMContentLoaded', async () => {
-      initAuth();
-      await window.authReady;
-      sessionStorage.setItem('postLoginRedirect', '/');
-      auth.login();
-    });
+  <script type="module">
+    await window.authReady;
+    sessionStorage.setItem('postLoginRedirect', '/');
+    auth.login();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Self-invoke auth initialization and expose `showAuthError` to signal missing Auth0 SDK or config
- Drop `DOMContentLoaded` listeners in favor of module scripts that await `authReady`
- Keep sign-in links navigable and surface auth errors via banner

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0d81d4ee48328a1c99e1f02a5c980