### PR TITLE
Handle Auth0 init failures in login flow

### DIFF
--- a/public/login/index.html
+++ b/public/login/index.html
@@ -15,11 +15,21 @@
   <script src="/auth/auth.js" defer></script>
 </head>
 <body>
-  <p>Redirecting…</p>
+  <p id="login-status">Redirecting…</p>
   <script type="module">
-    await window.authReady;
-    sessionStorage.setItem('postLoginRedirect', '/profile.html');
-    auth.login();
+    try {
+      await window.authReady;
+      sessionStorage.setItem('postLoginRedirect', '/profile.html');
+      auth.login();
+    } catch (e) {
+      const p = document.getElementById('login-status');
+      p.textContent = 'Auth0 init failed — missing domain/client/audience';
+      const link = document.createElement('a');
+      link.href = '/';
+      link.textContent = 'Back to Home';
+      document.body.appendChild(document.createTextNode(' '));
+      document.body.appendChild(link);
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Reject `authReady` when Auth0 config or SDK is missing and show inline errors
- Provide `getApiToken` helper in all auth paths and finalize state on failures
- Login page now reports Auth0 init errors and offers a Home link

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0ec174ebc8328901c45341dd680a1