### PR TITLE
feat: add reusable header and OpenAI news page

### DIFF
--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -10,8 +10,12 @@
   <meta name="auth0-domain"     content="dev-zi3ojkfg51ob4f3c.eu.auth0.com" />
   <meta name="auth0-audience"   content="https://ai-news-hub-eta.vercel.app/api" />
 
-  <!-- Site Styles (falls vorhanden) -->
-  <link rel="stylesheet" href="/resources/site.css" />
+    <!-- Site Styles (falls vorhanden) -->
+    <link rel="stylesheet" href="/resources/site.css" />
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
 
   <!-- Auth0 SDK zuerst, dann dein Helper -->
   <script src="https://cdn.auth0.com/js/auth0-spa-js/2.1/auth0-spa-js.production.js"></script>
@@ -34,6 +38,18 @@
   </style>
 </head>
 <body>
+  <header>
+    <div id="site-header"></div>
+  </header>
+  <script src="/scripts/include-header.js" defer></script>
+  <script src="/scripts/theme.js" defer></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', async () => {
+      await window.mountHeader('#site-header');
+      window.initHeaderAuth();
+      window.initThemeToggle();
+    });
+  </script>
   <div class="wrap">
     <h1>Admin Dashboard</h1>
 

--- a/public/data/posts.json
+++ b/public/data/posts.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "p-001",
+    "title": "OpenAI releases GPT-5 preview",
+    "date": "2025-08-15",
+    "category": "OpenAI",
+    "href": "/posts/gpt5-preview.html",
+    "excerpt": "Enhanced reasoning, longer context, and safer defaults…"
+  }
+]

--- a/public/index.html
+++ b/public/index.html
@@ -94,49 +94,18 @@
   </div>
 
   <!-- Header -->
-  <header class="sticky-nav bg-white/80 dark:bg-dark/80 py-4 border-b border-slate-200 dark:border-slate-800 shadow-sm">
-    <div class="max-w-6xl mx-auto px-4">
-      <div class="flex items-center justify-between">
-        <a class="flex items-center" href="#">
-          <span class="w-10 h-10 rounded-full bg-gradient-to-r from-primary to-secondary flex items-center justify-center mr-3">
-            <i class="fa-solid fa-brain text-white text-lg"></i>
-          </span>
-          <span class="text-2xl font-bold bg-clip-text text-transparent gradient-bg">AI News Hub</span>
-        </a>
-
-        <nav class="hidden md:flex items-center gap-1">
-          <a href="#openai"   class="px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">OpenAI News</a>
-          <a href="#chatgpt"  class="px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">ChatGPT Updates</a>
-          <a href="#industry" class="px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">AI Industry</a>
-          <a href="#research" class="px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Research & Innovation</a>
-        </nav>
-
-        <div class="flex items-center gap-4">
-          <div class="relative">
-            <input id="search-input" type="text" placeholder="Search…" class="pl-10 pr-4 py-2 rounded-full bg-slate-100 dark:bg-slate-800 text-sm w-40 md:w-64 focus:outline-none focus:ring-2 focus:ring-primary" />
-            <i class="fa-solid fa-search absolute left-3 top-1/2 -translate-y-1/2 text-slate-400"></i>
-            <div id="search-results" class="absolute left-0 mt-2 w-full bg-white dark:bg-slate-800 rounded-lg shadow-xl z-20 hidden"></div>
-          </div>
-
-          <div id="auth-area" class="flex items-center gap-2">
-            <span id="user-name" class="font-medium hidden"></span>
-            <button id="sign-in-btn" onclick="(sessionStorage.setItem('postLoginRedirect', location.pathname+location.search), auth.login())" class="hidden px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Sign in</button>
-            <button id="sign-out-btn" onclick="auth.logout()" class="hidden px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Sign out</button>
-            <a id="dashboard-link" href="/profile.html" class="hidden px-4 py-2 rounded-lg font-medium hover:bg-slate-100 dark:hover:bg-slate-800">Dashboard</a>
-          </div>
-
-          <button id="theme-toggle" class="w-10 h-10 rounded-full bg-slate-100 dark:bg-slate-800 flex items-center justify-center hover:bg-slate-200 dark:hover:bg-slate-700">
-            <i class="fa-solid fa-sun block dark:hidden text-yellow-500"></i>
-            <i class="fa-solid fa-moon hidden dark:block text-slate-200"></i>
-          </button>
-
-          <button class="md:hidden text-slate-700 dark:text-slate-300">
-            <i class="fa-solid fa-bars text-xl"></i>
-          </button>
-        </div>
-      </div>
-    </div>
+  <header>
+    <div id="site-header"></div>
   </header>
+  <script src="/scripts/include-header.js" defer></script>
+  <script src="/scripts/theme.js" defer></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', async () => {
+      await window.mountHeader('#site-header');
+      window.initHeaderAuth();
+      window.initThemeToggle();
+    });
+  </script>
 
   <!-- Hero -->
   <section class="relative py-16 md:py-24 bg-gradient-to-r from-blue-900 to-indigo-900 dark:from-slate-900 dark:to-slate-900 text-white overflow-hidden">
@@ -285,17 +254,6 @@
 
   <!-- Scripts -->
   <script>
-    // -------- Theme toggle --------
-    const htmlEl = document.documentElement;
-    const themeToggle = document.getElementById('theme-toggle');
-    const savedTheme = localStorage.getItem('theme');
-    if (savedTheme === 'dark') htmlEl.classList.add('dark');
-
-    themeToggle.addEventListener('click', () => {
-      htmlEl.classList.toggle('dark');
-      localStorage.setItem('theme', htmlEl.classList.contains('dark') ? 'dark' : 'light');
-    });
-
     // -------- Helpers --------
     const byId = id => document.getElementById(id);
     const openaiGrid   = byId('openai-grid');
@@ -303,8 +261,8 @@
     const industryGrid = byId('industry-grid');
     const researchGrid = byId('research-grid');
     const trendingList = byId('trending-list');
-    const searchInput  = byId('search-input');
-    const searchResults= byId('search-results');
+      const searchInput  = byId('search-input');
+      const searchResults= byId('search-results');
     const grids = [openaiGrid, chatgptGrid, industryGrid, researchGrid];
 
     const fmtDate = (iso) => new Date(iso || Date.now()).toISOString().slice(0,10);
@@ -428,24 +386,26 @@
                </li>`).join('')
           : '<li class="text-slate-500">No data yet.</li>';
 
-        searchInput.addEventListener('input', () => {
-          const q = searchInput.value.trim().toLowerCase();
-          if (q.length < 2) { searchResults.classList.add('hidden'); return; }
-          const matches = posts.filter(p => p.title?.toLowerCase().includes(q)).slice(0,8);
-          searchResults.innerHTML = matches.length
-            ? matches.map(m => `
-              <a class="block p-3 hover:bg-slate-100 dark:hover:bg-slate-700 border-b border-slate-200 dark:border-slate-700 last:border-0" href="/post.html?slug=${encodeURIComponent(m.slug)}">
-                <div class="font-semibold">${m.title}</div>
-                <div class="text-xs text-slate-500">${m.category}</div>
-              </a>`).join('')
-            : '<div class="p-3 text-slate-500 text-sm">No results</div>';
-          searchResults.classList.remove('hidden');
-        });
-        document.addEventListener('click', (e) => {
-          if (!searchResults.contains(e.target) && e.target !== searchInput) {
-            searchResults.classList.add('hidden');
-          }
-        });
+        if (searchInput && searchResults) {
+          searchInput.addEventListener('input', () => {
+            const q = searchInput.value.trim().toLowerCase();
+            if (q.length < 2) { searchResults.classList.add('hidden'); return; }
+            const matches = posts.filter(p => p.title?.toLowerCase().includes(q)).slice(0,8);
+            searchResults.innerHTML = matches.length
+              ? matches.map(m => `
+                <a class="block p-3 hover:bg-slate-100 dark:hover:bg-slate-700 border-b border-slate-200 dark:border-slate-700 last:border-0" href="/post.html?slug=${encodeURIComponent(m.slug)}">
+                  <div class="font-semibold">${m.title}</div>
+                  <div class="text-xs text-slate-500">${m.category}</div>
+                </a>`).join('')
+              : '<div class="p-3 text-slate-500 text-sm">No results</div>';
+            searchResults.classList.remove('hidden');
+          });
+          document.addEventListener('click', (e) => {
+            if (!searchResults.contains(e.target) && e.target !== searchInput) {
+              searchResults.classList.add('hidden');
+            }
+          });
+        }
 
       } catch (err) {
         console.error('Load error:', err);
@@ -458,28 +418,6 @@
     byId('year').textContent = new Date().getFullYear();
 
     document.addEventListener('DOMContentLoaded', loadAll);
-  </script>
-  <script>
-    window.addEventListener('DOMContentLoaded', async () => {
-      await auth.ready;
-      const signInBtn = document.getElementById('sign-in-btn');
-      const signOutBtn = document.getElementById('sign-out-btn');
-      const userName = document.getElementById('user-name');
-      const dashboardLink = document.getElementById('dashboard-link');
-      if (await auth.isAuthenticated()) {
-        const user = await auth.getUser();
-        userName.textContent = user.name || user.email;
-        userName.classList.remove('hidden');
-        signInBtn.classList.add('hidden');
-        signOutBtn.classList.remove('hidden');
-        if (dashboardLink) dashboardLink.classList.remove('hidden');
-      } else {
-        userName.classList.add('hidden');
-        signInBtn.classList.remove('hidden');
-        signOutBtn.classList.add('hidden');
-        if (dashboardLink) dashboardLink.classList.add('hidden');
-      }
-    });
   </script>
 </body>
 </html>

--- a/public/legal/cookie-policy.html
+++ b/public/legal/cookie-policy.html
@@ -4,10 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Cookie Policy - AI News Hub</title>
-  <script>
-    document.documentElement.dataset.theme = localStorage.theme || 'light';
-    if (document.documentElement.dataset.theme === 'dark') document.documentElement.classList.add('dark');
-  </script>
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = {
@@ -22,16 +18,19 @@
   </script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
 </head>
-<body class="bg-light dark:bg-dark text-slate-900 dark:text-slate-100 font-inter">
-  <header class="bg-white dark:bg-slate-900 border-b border-slate-200 dark:border-slate-800">
-    <div class="max-w-7xl mx-auto flex justify-between items-center p-4">
-      <a href="/" class="text-xl font-bold">AI News Hub</a>
-      <nav class="flex gap-4 text-sm">
-        <a href="/login" class="hover:underline">Sign in</a>
-        <a href="/signup" class="hover:underline">Sign up</a>
-      </nav>
-    </div>
-  </header>
+  <body class="bg-light dark:bg-dark text-slate-900 dark:text-slate-100 font-inter">
+    <header>
+      <div id="site-header"></div>
+    </header>
+    <script src="/scripts/include-header.js" defer></script>
+    <script src="/scripts/theme.js" defer></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', async () => {
+        await window.mountHeader('#site-header');
+        window.initHeaderAuth();
+        window.initThemeToggle();
+      });
+    </script>
   <main class="max-w-3xl mx-auto p-6">
     <h1 class="text-3xl font-bold mb-4">Cookie Policy</h1>
     <section class="space-y-4 text-slate-700 dark:text-slate-300">

--- a/public/legal/privacy.html
+++ b/public/legal/privacy.html
@@ -10,43 +10,9 @@
   <meta name="auth0-domain" content="dev-zi3ojkfg51ob4f3c.eu.auth0.com">
   <meta name="auth0-audience" content="https://ai-news-hub-eta.vercel.app/api">
   <!-- 1) Auth0 SPA SDK -->
-<script src="https://cdn.auth0.com/js/auth0-spa-js/2.1/auth0-spa-js.production.js"></script>
-<!-- 2) Your helper that wires up login/logout -->
-<script src="/auth/auth.js" defer></script>
-
-  <script>
-    document.documentElement.dataset.theme = localStorage.theme || 'light';
-    if (document.documentElement.dataset.theme === 'dark') document.documentElement.classList.add('dark');
-  </script>
-  <script src="https://cdn.tailwindcss.com"></script>
-  <script>
-    tailwind.config = {
-      darkMode: 'class',
-      theme: {
-        extend: {
-          colors: { primary:'#0ea5e9', secondary:'#06b6d4', dark:'#0f172a', light:'#f8fafc', accent:'#818cf8' },
-          fontFamily: { inter: ['Inter','system-ui','sans-serif'] }
-        }
-   <!DOCTYPE html>
-<html lang="en" class="scroll-smooth">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Privacy Policy - AI News Hub</title>
-
-  <!-- Auth0: DO NOT CHANGE -->
-  <meta name="auth0-client-id" content="a2MdQnWFC2HOqBY09V4EZ7KOFjj3fXNK">
-  <meta name="auth0-domain" content="dev-zi3ojkfg51ob4f3c.eu.auth0.com">
-  <meta name="auth0-audience" content="https://ai-news-hub-eta.vercel.app/api">
-  <!-- 1) Auth0 SPA SDK -->
   <script src="https://cdn.auth0.com/js/auth0-spa-js/2.1/auth0-spa-js.production.js"></script>
   <!-- 2) Your helper -->
   <script src="/auth/auth.js" defer></script>
-
-  <script>
-    document.documentElement.dataset.theme = localStorage.theme || 'light';
-    if (document.documentElement.dataset.theme === 'dark') document.documentElement.classList.add('dark');
-  </script>
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = {
@@ -63,48 +29,19 @@
   <link rel="stylesheet" href="/resources/site.css" />
   <script src="/public/js/cookie-banner.js" defer></script>
 </head>
-
 <body class="bg-light dark:bg-dark text-slate-900 dark:text-slate-100 font-inter">
-  <!-- Header -->
-  <header class="bg-white dark:bg-slate-900 border-b border-slate-200 dark:border-slate-800">
-    <div class="max-w-7xl mx-auto flex justify-between items-center p-4">
-      <!-- Left side -->
-      <div class="flex items-center gap-8">
-        <a href="/" class="flex items-center gap-2 text-xl font-bold">
-          <span class="text-primary">AI</span> News Hub
-        </a>
-        <nav class="hidden md:flex gap-6 text-sm">
-          <a href="/news.html" class="hover:text-primary">OpenAI News</a>
-          <a href="/updates.html" class="hover:text-primary">ChatGPT Updates</a>
-          <a href="/industry.html" class="hover:text-primary">AI Industry</a>
-          <a href="/research.html" class="hover:text-primary">Research & Innovation</a>
-        </nav>
-      </div>
-
-      <!-- Right side -->
-      <div class="flex items-center gap-4">
-        <div id="authSection" class="flex items-center gap-3">
-          <!-- Default: signed out -->
-          <a id="signInBtn" href="/login" class="hover:underline">Sign in</a>
-          <a id="signUpBtn" href="/signup" class="hover:underline">Sign up</a>
-
-          <!-- Signed in -->
-          <div id="profileMenu" class="hidden flex items-center gap-2">
-            <img id="navAvatar" class="w-8 h-8 rounded-full border border-slate-600" alt="Avatar" />
-            <a href="/profile.html" class="hover:underline">Profile</a>
-          </div>
-        </div>
-
-        <!-- Dashboard -->
-        <a href="/dashboard.html" class="px-3 py-1 rounded-md bg-primary hover:bg-secondary text-white text-sm">Dashboard</a>
-
-        <!-- Theme toggle -->
-        <button id="themeToggle" class="p-2 rounded-full bg-slate-200 dark:bg-slate-800 hover:bg-slate-300 dark:hover:bg-slate-700">
-          🌙
-        </button>
-      </div>
-    </div>
+  <header>
+    <div id="site-header"></div>
   </header>
+  <script src="/scripts/include-header.js" defer></script>
+  <script src="/scripts/theme.js" defer></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', async () => {
+      await window.mountHeader('#site-header');
+      window.initHeaderAuth();
+      window.initThemeToggle();
+    });
+  </script>
 <!-- Privacy Policy Content -->
   <main class="max-w-3xl mx-auto p-6">
     <div class="flex items-center justify-between mb-3">
@@ -226,24 +163,6 @@
       document.getElementById('printBtn').onclick = () => window.print();
       document.getElementById('copyLink')?.addEventListener("click", async () => {
         try { await navigator.clipboard.writeText(location.href); alert('Link copied'); } catch {}
-      });
-
-      // Auth check for nav
-      document.addEventListener("DOMContentLoaded", async () => {
-        if (!window.auth || !window.auth.ready) return;
-        try {
-          await window.auth.ready;
-          const isAuthed = await window.auth.isAuthenticated();
-          const user = isAuthed ? await window.auth.getUser() : null;
-          if (user) {
-            document.getElementById("signInBtn").style.display = "none";
-            document.getElementById("signUpBtn").style.display = "none";
-            const navAvatar = document.getElementById("navAvatar");
-            navAvatar.src = user.picture || "";
-            navAvatar.alt = user.name || user.email || "Avatar";
-            document.getElementById("profileMenu").classList.remove("hidden");
-          }
-        } catch (e) { console.error("Auth check failed:", e); }
       });
     </script>
   </footer>

--- a/public/legal/terms.html
+++ b/public/legal/terms.html
@@ -4,10 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Terms of Service - AI News Hub</title>
-  <script>
-    document.documentElement.dataset.theme = localStorage.theme || 'light';
-    if (document.documentElement.dataset.theme === 'dark') document.documentElement.classList.add('dark');
-  </script>
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = {
@@ -22,16 +18,19 @@
   </script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
 </head>
-<body class="bg-light dark:bg-dark text-slate-900 dark:text-slate-100 font-inter">
-  <header class="bg-white dark:bg-slate-900 border-b border-slate-200 dark:border-slate-800">
-    <div class="max-w-7xl mx-auto flex justify-between items-center p-4">
-      <a href="/" class="text-xl font-bold">AI News Hub</a>
-      <nav class="flex gap-4 text-sm">
-        <a href="/login" class="hover:underline">Sign in</a>
-        <a href="/signup" class="hover:underline">Sign up</a>
-      </nav>
-    </div>
-  </header>
+  <body class="bg-light dark:bg-dark text-slate-900 dark:text-slate-100 font-inter">
+    <header>
+      <div id="site-header"></div>
+    </header>
+    <script src="/scripts/include-header.js" defer></script>
+    <script src="/scripts/theme.js" defer></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', async () => {
+        await window.mountHeader('#site-header');
+        window.initHeaderAuth();
+        window.initThemeToggle();
+      });
+    </script>
   <main class="max-w-3xl mx-auto p-6">
     <h1 class="text-3xl font-bold mb-4">Terms of Service</h1>
     <section class="space-y-4 text-slate-700 dark:text-slate-300">

--- a/public/login/index.html
+++ b/public/login/index.html
@@ -7,14 +7,22 @@
   <meta name="auth0-client-id" content="a2MdQnWFC2HOqBY09V4EZ7KOFjj3fXNK"><!-- Auth0 Client ID injected at build time -->
   <meta name="auth0-domain" content="dev-zi3ojkfg51ob4f3c.eu.auth0.com"><!-- Auth0 Domain injected at build time -->
   <meta name="auth0-audience" content="https://ai-news-hub-eta.vercel.app/api" />
-  <script>
-    document.documentElement.dataset.theme = localStorage.theme || 'light';
-    if (document.documentElement.dataset.theme === 'dark') document.documentElement.classList.add('dark');
-  </script>
   <script src="https://cdn.auth0.com/js/auth0-spa-js/2.1/auth0-spa-js.production.js" defer></script>
   <script src="/auth/auth.js" defer></script>
 </head>
 <body>
+  <header>
+    <div id="site-header"></div>
+  </header>
+  <script src="/scripts/include-header.js" defer></script>
+  <script src="/scripts/theme.js" defer></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', async () => {
+      await window.mountHeader('#site-header');
+      window.initHeaderAuth();
+      window.initThemeToggle();
+    });
+  </script>
   <p id="login-status">Redirecting…</p>
   <script type="module">
     try {

--- a/public/openai-news.html
+++ b/public/openai-news.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>OpenAI News - AI News Hub</title>
+  <meta name="auth0-client-id" content="a2MdQnWFC2HOqBY09V4EZ7KOFjj3fXNK">
+  <meta name="auth0-domain" content="dev-zi3ojkfg51ob4f3c.eu.auth0.com">
+  <meta name="auth0-audience" content="https://ai-news-hub-eta.vercel.app/api" />
+  <script src="https://cdn.auth0.com/js/auth0-spa-js/2.1/auth0-spa-js.production.js" defer></script>
+  <script src="/auth/auth.js" defer></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      darkMode: 'class',
+      theme: { extend: { colors: { primary:'#0ea5e9', secondary:'#06b6d4', dark:'#0f172a', light:'#f8fafc', accent:'#818cf8' }, fontFamily:{ inter:['Inter','sans-serif'] } } }
+    };
+  </script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body class="bg-light dark:bg-dark font-inter text-slate-900 dark:text-slate-100">
+  <header>
+    <div id="site-header"></div>
+  </header>
+  <script src="/scripts/include-header.js" defer></script>
+  <script src="/scripts/theme.js" defer></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', async () => {
+      await window.mountHeader('#site-header');
+      window.initHeaderAuth();
+      window.initThemeToggle();
+    });
+  </script>
+
+  <main class="max-w-4xl mx-auto p-6">
+    <h1 class="text-3xl font-bold mb-6">OpenAI News</h1>
+    <div class="flex flex-wrap gap-2 mb-6">
+      <button data-category="All" class="px-3 py-1 rounded-full border">All</button>
+      <button data-category="OpenAI" class="px-3 py-1 rounded-full border">OpenAI</button>
+      <button data-category="ChatGPT" class="px-3 py-1 rounded-full border">ChatGPT</button>
+      <button data-category="Research" class="px-3 py-1 rounded-full border">Research</button>
+      <button data-category="Policy" class="px-3 py-1 rounded-full border">Policy</button>
+    </div>
+    <div id="news-list" class="grid gap-4"></div>
+  </main>
+
+  <script src="/scripts/news.js" defer></script>
+</body>
+</html>

--- a/public/partials/header.html
+++ b/public/partials/header.html
@@ -1,0 +1,28 @@
+<div class="max-w-6xl mx-auto px-4 py-4 flex items-center justify-between">
+  <a href="/" class="flex items-center gap-2">
+    <img src="/logo.png" alt="AI News Hub" class="w-10 h-10 rounded-full"/>
+    <span class="text-2xl font-bold">AI News Hub</span>
+  </a>
+  <nav class="hidden md:flex items-center gap-4">
+    <a href="/openai-news.html" class="px-3 py-2 rounded hover:bg-slate-100 dark:hover:bg-slate-800">OpenAI News</a>
+    <a href="/updates.html" class="px-3 py-2 rounded hover:bg-slate-100 dark:hover:bg-slate-800">ChatGPT Updates</a>
+    <a href="/industry.html" class="px-3 py-2 rounded hover:bg-slate-100 dark:hover:bg-slate-800">AI Industry</a>
+    <a href="/research.html" class="px-3 py-2 rounded hover:bg-slate-100 dark:hover:bg-slate-800">Research &amp; Innovation</a>
+  </nav>
+  <div class="flex items-center gap-3">
+    <input type="text" placeholder="Search" class="hidden sm:block px-2 py-1 border rounded-md text-sm"/>
+    <button id="themeToggle" class="p-2 rounded-md hover:bg-slate-200 dark:hover:bg-slate-700">
+      <i class="fa-solid fa-sun dark:hidden"></i>
+      <i class="fa-solid fa-moon hidden dark:inline"></i>
+    </button>
+    <div id="authSection" class="flex items-center gap-2">
+      <a id="signInBtn" href="/login" class="text-sm hover:underline">Sign in</a>
+      <a id="signUpBtn" href="/signup" class="text-sm hover:underline">Sign up</a>
+      <div id="profileMenu" class="hidden items-center gap-2">
+        <img id="navAvatar" class="w-8 h-8 rounded-full border" alt="Avatar"/>
+        <a href="/profile.html" class="text-sm hover:underline">Profile</a>
+        <a href="/dashboard.html" class="px-3 py-1 text-sm rounded-full bg-primary text-white">Dashboard</a>
+      </div>
+    </div>
+  </div>
+</div>

--- a/public/post.html
+++ b/public/post.html
@@ -9,10 +9,6 @@
   <meta name="auth0-client-id" content="a2MdQnWFC2HOqBY09V4EZ7KOFjj3fXNK"><!-- Auth0 Client ID injected at build time -->
   <meta name="auth0-domain" content="dev-zi3ojkfg51ob4f3c.eu.auth0.com"><!-- Auth0 Domain injected at build time -->
   <meta name="auth0-audience" content="https://ai-news-hub-eta.vercel.app/api" />
-  <script type="module">
-    document.documentElement.dataset.theme = localStorage.theme || 'light';
-    if (document.documentElement.dataset.theme === 'dark') document.documentElement.classList.add('dark');
-  </script>
   <script src="https://cdn.auth0.com/js/auth0-spa-js/2.1/auth0-spa-js.production.js" defer></script>
   <script src="/auth/auth.js" defer></script>
   <!-- Tailwind & Icons -->
@@ -27,8 +23,20 @@
     .dark body{background:#0f172a;color:#e2e8f0}
   </style>
 </head>
-<body class="bg-light dark:bg-dark">
-  <main id="post-container" class="max-w-3xl mx-auto p-6"></main>
+  <body class="bg-light dark:bg-dark">
+    <header>
+      <div id="site-header"></div>
+    </header>
+    <script src="/scripts/include-header.js" defer></script>
+    <script src="/scripts/theme.js" defer></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', async () => {
+        await window.mountHeader('#site-header');
+        window.initHeaderAuth();
+        window.initThemeToggle();
+      });
+    </script>
+    <main id="post-container" class="max-w-3xl mx-auto p-6"></main>
   <script>
     let currentUser = null;
     let currentPostId = null;

--- a/public/profile.html
+++ b/public/profile.html
@@ -10,8 +10,12 @@
   <meta name="auth0-domain" content="dev-zi3ojkfg51ob4f3c.eu.auth0.com">
   <meta name="auth0-audience" content="https://ai-news-hub-eta.vercel.app/api">
 
-  <!-- Site-wide resources (if present) -->
-  <link rel="stylesheet" href="/resources/site.css" />
+    <!-- Site-wide resources (if present) -->
+    <link rel="stylesheet" href="/resources/site.css" />
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
 
   <!-- Load Auth0 SDK first, then your helper -->
   <script src="https://cdn.auth0.com/js/auth0-spa-js/2.1/auth0-spa-js.production.js"></script>
@@ -104,6 +108,18 @@
   </style>
 </head>
 <body>
+  <header>
+    <div id="site-header"></div>
+  </header>
+  <script src="/scripts/include-header.js" defer></script>
+  <script src="/scripts/theme.js" defer></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', async () => {
+      await window.mountHeader('#site-header');
+      window.initHeaderAuth();
+      window.initThemeToggle();
+    });
+  </script>
   <div class="wrap">
     <div class="page-head">
       <div class="title"><span class="dot"></span><h1>Profile</h1></div>

--- a/public/resources/events.html
+++ b/public/resources/events.html
@@ -4,10 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Events Calendar - AI News Hub</title>
-  <script>
-    document.documentElement.dataset.theme = localStorage.theme || 'light';
-    if (document.documentElement.dataset.theme === 'dark') document.documentElement.classList.add('dark');
-  </script>
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = {
@@ -22,16 +18,19 @@
   </script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
 </head>
-<body class="bg-light dark:bg-dark text-slate-900 dark:text-slate-100 font-inter">
-  <header class="bg-white dark:bg-slate-900 border-b border-slate-200 dark:border-slate-800">
-    <div class="max-w-7xl mx-auto flex justify-between items-center p-4">
-      <a href="/" class="text-xl font-bold">AI News Hub</a>
-      <nav class="flex gap-4 text-sm">
-        <a href="/login" class="hover:underline">Sign in</a>
-        <a href="/signup" class="hover:underline">Sign up</a>
-      </nav>
-    </div>
-  </header>
+  <body class="bg-light dark:bg-dark text-slate-900 dark:text-slate-100 font-inter">
+    <header>
+      <div id="site-header"></div>
+    </header>
+    <script src="/scripts/include-header.js" defer></script>
+    <script src="/scripts/theme.js" defer></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', async () => {
+        await window.mountHeader('#site-header');
+        window.initHeaderAuth();
+        window.initThemeToggle();
+      });
+    </script>
   <main class="max-w-3xl mx-auto p-6">
     <h1 class="text-3xl font-bold mb-4">Events Calendar</h1>
     <section class="space-y-4 text-slate-700 dark:text-slate-300">

--- a/public/resources/glossary.html
+++ b/public/resources/glossary.html
@@ -4,10 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>AI Glossary - AI News Hub</title>
-  <script>
-    document.documentElement.dataset.theme = localStorage.theme || 'light';
-    if (document.documentElement.dataset.theme === 'dark') document.documentElement.classList.add('dark');
-  </script>
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = {
@@ -22,16 +18,19 @@
   </script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
 </head>
-<body class="bg-light dark:bg-dark text-slate-900 dark:text-slate-100 font-inter">
-  <header class="bg-white dark:bg-slate-900 border-b border-slate-200 dark:border-slate-800">
-    <div class="max-w-7xl mx-auto flex justify-between items-center p-4">
-      <a href="/" class="text-xl font-bold">AI News Hub</a>
-      <nav class="flex gap-4 text-sm">
-        <a href="/login" class="hover:underline">Sign in</a>
-        <a href="/signup" class="hover:underline">Sign up</a>
-      </nav>
-    </div>
-  </header>
+  <body class="bg-light dark:bg-dark text-slate-900 dark:text-slate-100 font-inter">
+    <header>
+      <div id="site-header"></div>
+    </header>
+    <script src="/scripts/include-header.js" defer></script>
+    <script src="/scripts/theme.js" defer></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', async () => {
+        await window.mountHeader('#site-header');
+        window.initHeaderAuth();
+        window.initThemeToggle();
+      });
+    </script>
   <main class="max-w-3xl mx-auto p-6">
     <h1 class="text-3xl font-bold mb-4">AI Glossary</h1>
     <section class="space-y-4 text-slate-700 dark:text-slate-300">

--- a/public/resources/research.html
+++ b/public/resources/research.html
@@ -4,10 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Research Papers - AI News Hub</title>
-  <script>
-    document.documentElement.dataset.theme = localStorage.theme || 'light';
-    if (document.documentElement.dataset.theme === 'dark') document.documentElement.classList.add('dark');
-  </script>
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = {
@@ -22,16 +18,19 @@
   </script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
 </head>
-<body class="bg-light dark:bg-dark text-slate-900 dark:text-slate-100 font-inter">
-  <header class="bg-white dark:bg-slate-900 border-b border-slate-200 dark:border-slate-800">
-    <div class="max-w-7xl mx-auto flex justify-between items-center p-4">
-      <a href="/" class="text-xl font-bold">AI News Hub</a>
-      <nav class="flex gap-4 text-sm">
-        <a href="/login" class="hover:underline">Sign in</a>
-        <a href="/signup" class="hover:underline">Sign up</a>
-      </nav>
-    </div>
-  </header>
+  <body class="bg-light dark:bg-dark text-slate-900 dark:text-slate-100 font-inter">
+    <header>
+      <div id="site-header"></div>
+    </header>
+    <script src="/scripts/include-header.js" defer></script>
+    <script src="/scripts/theme.js" defer></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', async () => {
+        await window.mountHeader('#site-header');
+        window.initHeaderAuth();
+        window.initThemeToggle();
+      });
+    </script>
   <main class="max-w-3xl mx-auto p-6">
     <h1 class="text-3xl font-bold mb-4">Research Papers</h1>
     <section class="space-y-4 text-slate-700 dark:text-slate-300">

--- a/public/resources/tutorials.html
+++ b/public/resources/tutorials.html
@@ -4,10 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Tutorials - AI News Hub</title>
-  <script>
-    document.documentElement.dataset.theme = localStorage.theme || 'light';
-    if (document.documentElement.dataset.theme === 'dark') document.documentElement.classList.add('dark');
-  </script>
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = {
@@ -22,16 +18,19 @@
   </script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
 </head>
-<body class="bg-light dark:bg-dark text-slate-900 dark:text-slate-100 font-inter">
-  <header class="bg-white dark:bg-slate-900 border-b border-slate-200 dark:border-slate-800">
-    <div class="max-w-7xl mx-auto flex justify-between items-center p-4">
-      <a href="/" class="text-xl font-bold">AI News Hub</a>
-      <nav class="flex gap-4 text-sm">
-        <a href="/login" class="hover:underline">Sign in</a>
-        <a href="/signup" class="hover:underline">Sign up</a>
-      </nav>
-    </div>
-  </header>
+  <body class="bg-light dark:bg-dark text-slate-900 dark:text-slate-100 font-inter">
+    <header>
+      <div id="site-header"></div>
+    </header>
+    <script src="/scripts/include-header.js" defer></script>
+    <script src="/scripts/theme.js" defer></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', async () => {
+        await window.mountHeader('#site-header');
+        window.initHeaderAuth();
+        window.initThemeToggle();
+      });
+    </script>
   <main class="max-w-3xl mx-auto p-6">
     <h1 class="text-3xl font-bold mb-4">Tutorials</h1>
     <section class="space-y-4 text-slate-700 dark:text-slate-300">

--- a/public/scripts/include-header.js
+++ b/public/scripts/include-header.js
@@ -1,0 +1,27 @@
+window.mountHeader = async function(selector = '#site-header') {
+  const el = document.querySelector(selector);
+  if (!el) return;
+  try {
+    const res = await fetch('/partials/header.html');
+    if (!res.ok) throw new Error('Failed to load header');
+    const html = await res.text();
+    el.innerHTML = html;
+  } catch (err) {
+    console.error('Header mount error', err);
+  }
+};
+
+window.initHeaderAuth = async function(){
+  if (!window.auth || !window.auth.ready) return;
+  await window.auth.ready;
+  const isAuthed = await window.auth.isAuthenticated();
+  const user = isAuthed ? await window.auth.getUser() : null;
+  if (user) {
+    document.getElementById('signInBtn').style.display = 'none';
+    document.getElementById('signUpBtn').style.display = 'none';
+    const avatar = document.getElementById('navAvatar');
+    avatar.src = user.picture || '';
+    avatar.alt = user.name || user.email || 'Avatar';
+    document.getElementById('profileMenu').classList.remove('hidden');
+  }
+};

--- a/public/scripts/news.js
+++ b/public/scripts/news.js
@@ -1,0 +1,34 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  const listEl = document.getElementById('news-list');
+  const filterEls = document.querySelectorAll('[data-category]');
+  let posts = [];
+  try {
+    const res = await fetch('/data/posts.json');
+    posts = await res.json();
+  } catch (e) {
+    console.error('Failed to load posts', e);
+  }
+  const render = (cat) => {
+    const sorted = posts.slice().sort((a,b) => new Date(b.date) - new Date(a.date));
+    const filtered = cat && cat !== 'All' ? sorted.filter(p => p.category === cat) : sorted;
+    listEl.innerHTML = filtered.map(p => `
+      <article class="p-4 rounded-lg bg-white dark:bg-slate-800 shadow mb-4">
+        <a href="${p.href}" class="block font-semibold text-lg mb-1">${p.title}</a>
+        <div class="text-sm text-slate-500 mb-2 flex items-center gap-2">
+          <span>${new Date(p.date).toLocaleDateString()}</span>
+          <span class="px-2 py-0.5 rounded-full bg-primary text-white text-xs">${p.category}</span>
+        </div>
+        <p class="text-slate-600 dark:text-slate-300 text-sm">${p.excerpt}</p>
+      </article>
+    `).join('') || '<p class="text-slate-500">No posts found.</p>';
+  };
+  filterEls.forEach(btn => btn.addEventListener('click', () => {
+    filterEls.forEach(b => b.classList.remove('bg-primary','text-white'));
+    btn.classList.add('bg-primary','text-white');
+    render(btn.dataset.category);
+  }));
+  // default select first (All)
+  const first = document.querySelector('[data-category].active') || filterEls[0];
+  if (first) first.classList.add('bg-primary','text-white');
+  render(first ? first.dataset.category : 'All');
+});

--- a/public/scripts/theme.js
+++ b/public/scripts/theme.js
@@ -1,0 +1,12 @@
+window.initThemeToggle = function(){
+  const btn = document.getElementById('themeToggle');
+  if (!btn) return;
+  const apply = (mode) => {
+    document.documentElement.dataset.theme = mode;
+    document.documentElement.classList.toggle('dark', mode === 'dark');
+    localStorage.theme = mode;
+  };
+  const current = localStorage.theme || 'light';
+  apply(current);
+  btn.onclick = () => apply((localStorage.theme === 'dark') ? 'light' : 'dark');
+};

--- a/public/signup/index.html
+++ b/public/signup/index.html
@@ -7,15 +7,23 @@
   <meta name="auth0-client-id" content="a2MdQnWFC2HOqBY09V4EZ7KOFjj3fXNK"><!-- Auth0 Client ID injected at build time -->
   <meta name="auth0-domain" content="dev-zi3ojkfg51ob4f3c.eu.auth0.com"><!-- Auth0 Domain injected at build time -->
   <meta name="auth0-audience" content="https://ai-news-hub-eta.vercel.app/api" />
-  <script>
-    document.documentElement.dataset.theme = localStorage.theme || 'light';
-    if (document.documentElement.dataset.theme === 'dark') document.documentElement.classList.add('dark');
-  </script>
   <script src="https://cdn.auth0.com/js/auth0-spa-js/2.1/auth0-spa-js.production.js" defer></script>
   <script src="/auth/auth.js" defer></script>
 </head>
-<body>
-  <p>Redirecting…</p>
+  <body>
+    <header>
+      <div id="site-header"></div>
+    </header>
+    <script src="/scripts/include-header.js" defer></script>
+    <script src="/scripts/theme.js" defer></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', async () => {
+        await window.mountHeader('#site-header');
+        window.initHeaderAuth();
+        window.initThemeToggle();
+      });
+    </script>
+    <p>Redirecting…</p>
   <script type="module">
     await window.authReady;
     sessionStorage.setItem('postLoginRedirect', '/');


### PR DESCRIPTION
## Summary
- add universal header partial with auth and theme toggle
- create OpenAI News page with category filters
- wire theme toggler and header loader across pages, fixing privacy page toggle

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a216f3516883289980b764569f7a79